### PR TITLE
feat: add duration param to approve method

### DIFF
--- a/Exchange.sol
+++ b/Exchange.sol
@@ -10,18 +10,20 @@ interface IExchangeModule {
    ****************************************************************************/
    
    /// @dev Approves a list of Cosmos messages.
-   /// @param grantee The account address which will have an authorization to spend the origin funds.
+   /// @param grantee The account address which will be authorized to spend the origin's funds.
    /// @param methods The message type URLs of the methods to approve.
    /// @param spendLimit The spend limit for the methods.
+   /// @param duration The time period for which the authorization is valid (in seconds).
    /// @return approved Boolean value to indicate if the approval was successful.
    function approve(
       address grantee,
       ExchangeTypes.MsgType[] calldata methods,
-      Cosmos.Coin[] calldata spendLimit
+      Cosmos.Coin[] calldata spendLimit,
+      uint256 duration
    ) external returns (bool approved);
 
    /// @dev Revokes a list of Cosmos messages.
-   /// @param grantee The contract address which will have its allowances revoked.
+   /// @param grantee The account address which will have its allowances revoked.
    /// @param methods The message type URLs of the methods to revoke.
    /// @return revoked Boolean value to indicate if the revocation was successful.
    function revoke(
@@ -31,7 +33,7 @@ interface IExchangeModule {
 
    /// @dev Checks if there is a valid grant from granter to grantee for specified
    /// message type
-   /// @param grantee The contract address which has the Authorization.
+   /// @param grantee The account address which has the Authorization.
    /// @param granter The account address that grants an Authorization.
    /// @param method The message type URL of the methods for which the approval should be queried.
    /// @return allowed Boolean value to indicatie if the grant exists and is not expired

--- a/ExchangeProxy.sol
+++ b/ExchangeProxy.sol
@@ -13,15 +13,17 @@ contract ExchangeProxy {
     /// behalf of the origin. 
     /// @param msgType The type of the message to approve.
     /// @param spendLimit The spend limit for the message type.
+    /// @param duration The time period for which the authorization is valid (in seconds).
     /// @return success Boolean value to indicate if the approval was successful.
     function approve(
         ExchangeTypes.MsgType msgType,
-        Cosmos.Coin[] memory spendLimit
+        Cosmos.Coin[] memory spendLimit,
+        uint256 duration
     ) external returns (bool success) {
         ExchangeTypes.MsgType[] memory methods = new ExchangeTypes.MsgType[](1);
         methods[0] = msgType;
-
-        try exchange.approve(address(this), methods, spendLimit) returns (bool approved) {
+        
+        try exchange.approve(address(this), methods, spendLimit, duration) returns (bool approved) {
             return approved;
         } catch {
             revert("error approving msg with spend limit");

--- a/ExchangeTest.sol
+++ b/ExchangeTest.sol
@@ -55,15 +55,17 @@ contract ExchangeTest {
     /// behalf of the origin. 
     /// @param msgType The type of the message to approve.
     /// @param spendLimit The spend limit for the message type.
+    /// @param duration The time period for which the authorization is valid (in seconds).
     /// @return success Boolean value to indicate if the approval was successful.
     function approve(
         ExchangeTypes.MsgType msgType,
-        Cosmos.Coin[] memory spendLimit
+        Cosmos.Coin[] memory spendLimit,
+        uint256 duration
     ) external returns (bool success) {
         ExchangeTypes.MsgType[] memory methods = new ExchangeTypes.MsgType[](1);
         methods[0] = msgType;
 
-        try exchange.approve(address(this), methods, spendLimit) returns (bool approved) {
+        try exchange.approve(address(this), methods, spendLimit, duration) returns (bool approved) {
             return approved;
         } catch {
             revert("error approving msg with spend limit");


### PR DESCRIPTION
Adds the `duration` parameter to the `approve` methods.
This is expressed in seconds to add to the current block time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added time-based authorization duration to the `approve` function
  - Enhanced approval functionality with expiration control

- **Documentation**
  - Improved clarity of documentation comments for `approve` and `allowance` functions
  - Added explanatory comments for new `duration` parameter

- **Refactor**
  - Updated method signatures across multiple contracts to support time-limited authorizations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->