### PR TITLE
feat: add BankOFT.sol to Injective solidity contracts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/devtools"]
 	path = lib/devtools
 	url = https://github.com/LayerZero-Labs/devtools
+[submodule "lib/layerzero-v2"]
+	path = lib/layerzero-v2
+	url = https://github.com/LayerZero-Labs/layerzero-v2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
+[submodule "lib/devtools"]
+	path = lib/devtools
+	url = https://github.com/LayerZero-Labs/devtools

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,6 +3,13 @@ src = "src"
 out = "out"
 libs = ["lib"]
 
+remappings = [
+    '@layerzerolabs/oft-evm/=lib/devtools/packages/oft-evm/',
+    '@layerzerolabs/oapp-evm/=lib/devtools/packages/oapp-evm/',
+    '@layerzerolabs/lz-evm-protocol-v2/=lib/layerzero-v2/packages/layerzero-v2/evm/protocol',
+    '@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/',
+]
+
 [rpc_endpoints]
 evmixt = "https://k8s.testnet.evmix.json-rpc.injective.network"
 devnet = "https://devnet.json-rpc.injective.dev"

--- a/src/BankOFT.sol
+++ b/src/BankOFT.sol
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import { BankERC20 } from "./BankERC20.sol";
+import { IOFT, OFTCore } from "@layerzerolabs/oft-evm/contracts/OFTCore.sol";
+
+/**
+ * @title OFT Contract
+ * @dev OFT is an ERC-20 token that extends the functionality of the OFTCore contract.
+ */
+abstract contract OFT is OFTCore, BankERC20 {
+    /**
+     * @dev Constructor for the OFT contract.
+     * @param _name The name of the OFT.
+     * @param _symbol The symbol of the OFT.
+     * @param _lzEndpoint The LayerZero endpoint address.
+     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.
+     */
+    constructor(
+        string memory _name,
+        string memory _symbol,
+        uint8 _decimals,
+        address _lzEndpoint,
+        address _delegate
+    ) BankERC20(_name, _symbol, _decimals) OFTCore(_decimals, _lzEndpoint, _delegate) {}
+
+    /**
+     * @dev Retrieves the address of the underlying ERC20 implementation.
+     * @return The address of the OFT token.
+     *
+     * @dev In the case of OFT, address(this) and erc20 are the same contract.
+     */
+    function token() public view returns (address) {
+        return address(this);
+    }
+
+    /**
+     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.
+     * @return requiresApproval Needs approval of the underlying token implementation.
+     *
+     * @dev In the case of OFT where the contract IS the token, approval is NOT required.
+     */
+    function approvalRequired() external pure virtual returns (bool) {
+        return false;
+    }
+
+    /**
+     * @dev Burns tokens from the sender's specified balance.
+     * @param _from The address to debit the tokens from.
+     * @param _amountLD The amount of tokens to send in local decimals.
+     * @param _minAmountLD The minimum amount to send in local decimals.
+     * @param _dstEid The destination chain ID.
+     * @return amountSentLD The amount sent in local decimals.
+     * @return amountReceivedLD The amount received in local decimals on the remote.
+     */
+    function _debit(
+        address _from,
+        uint256 _amountLD,
+        uint256 _minAmountLD,
+        uint32 _dstEid
+    ) internal virtual override returns (uint256 amountSentLD, uint256 amountReceivedLD) {
+        (amountSentLD, amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);
+
+        // @dev In NON-default OFT, amountSentLD could be 100, with a 10% fee, the amountReceivedLD amount is 90,
+        // therefore amountSentLD CAN differ from amountReceivedLD.
+
+        // @dev Default OFT burns on src.
+        _burn(_from, amountSentLD);
+    }
+
+    /**
+     * @dev Credits tokens to the specified address.
+     * @param _to The address to credit the tokens to.
+     * @param _amountLD The amount of tokens to credit in local decimals.
+     * @dev _srcEid The source chain ID.
+     * @return amountReceivedLD The amount of tokens ACTUALLY received in local decimals.
+     */
+    function _credit(
+        address _to,
+        uint256 _amountLD,
+        uint32 /*_srcEid*/
+    ) internal virtual override returns (uint256 amountReceivedLD) {
+        if (_to == address(0x0)) _to = address(0xdead); // _mint(...) does not support address(0x0)
+        // @dev Default OFT mints on dst.
+        _mint(_to, _amountLD);
+        // @dev In the case of NON-default OFT, the _amountLD MIGHT not be == amountReceivedLD.
+        return _amountLD;
+    }
+}

--- a/src/oft-evm/BankOFT.sol
+++ b/src/oft-evm/BankOFT.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.20;
 
-import { BankERC20 } from "./BankERC20.sol";
+import { BankERC20 } from "../BankERC20.sol";
 import { IOFT, OFTCore } from "@layerzerolabs/oft-evm/contracts/OFTCore.sol";
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new abstract contract for omnichain ERC-20 token transfers, supporting cross-chain minting and burning according to the OFT standard.

- **Chores**
  - Added two new external dependencies to the project.
  - Updated configuration to support new library paths and remappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->