### PR TITLE
[CP-634] add batchCreateDerivativeLimitOrders to exchange-proxy contract

### DIFF
--- a/demos/exchange-direct/README.md
+++ b/demos/exchange-direct/README.md
@@ -1,10 +1,23 @@
-# Exchange Precompile Demo
+# Exchange Precompile Demo - Direct Contract Trading
 
 This demo shows how to write a smart-contract that uses the exchange precompile, 
 and how this smart-contract can be deployed and called using commonly used tools 
 like `forge` and `cast`.
 
-This demo goes through the following steps
+## Trading Methods
+
+This demo demonstrates the **exchange-direct** method, where the smart contract trades using its own funds and subaccount. The contract:
+- Manages its own deposits and withdrawals
+- Creates orders using its own balance
+- Does not require authorization from external users
+
+This is different from the **exchange-proxy** method (see `../exchange-proxy/` demo), where a smart contract trades on behalf of end users through authorization grants. 
+
+**Use exchange-direct when**: Your contract needs to trade autonomously with its own funds (e.g., AMM protocols, yield farming contracts, treasury management)
+
+**Use exchange-proxy when**: Your contract needs to execute trades on behalf of users while they retain custody of their funds
+
+This demo goes through the following steps:
 
 1) deploy `ExchangeDemo` contract
 2) Fund the contract account with some USDT

--- a/demos/exchange-direct/demo.sh
+++ b/demos/exchange-direct/demo.sh
@@ -71,7 +71,7 @@ if [ $? -ne 0 ]; then
 fi
 echo ""
 
-sleep 3
+
 injectived q bank balances \
     --chain-id $CHAIN_ID \
     --node $INJ_URL \

--- a/demos/exchange-proxy/README.md
+++ b/demos/exchange-proxy/README.md
@@ -1,16 +1,26 @@
-# Exchange Precompile Demo
+# Exchange Precompile Demo - Proxy Contract Method
 
-This demo shows how to write a smart-contract that uses the exchange precompile, 
-and how this smart-contract can be deployed and called using commonly used tools 
-like `forge` and `cast`.
+This demo demonstrates the **exchange-proxy** method, which differs from the **exchange-direct** method:
 
-This demo goes through the following steps
+- **Exchange-Direct**: The end user directly calls the exchange precompile functions from their wallet
+- **Exchange-Proxy**: The end user grants authorization to a smart contract, which then calls the exchange precompile on their behalf
+
+This proxy method is useful for:
+- Creating more complex trading logic in smart contracts
+- Implementing automated trading strategies
+- Building DeFi protocols that need to trade on behalf of users
+- Batching multiple operations together
+
+The key concept here is **authorization grants** - the end user must explicitly grant the proxy contract permission to trade on their behalf using Cosmos SDK's authz module.
+
+This demo goes through the following steps:
 
 1) Deposit funds in the trader's subaccount
 2) Deploy `ExchangeProxy` contract
 3) Create a grant from trader to contract for placing derivative limit orders
 4) Call the proxy contract to place an order
 5) Check that the order was created
+6) Verify that the spendable limit of the grant has decreased after the order submission
 
 ## Requirements
 

--- a/demos/exchange-proxy/demo.sh
+++ b/demos/exchange-proxy/demo.sh
@@ -47,6 +47,8 @@ yes 12345678 | injectived tx exchange deposit 2000000000000$QUOTE $user_subaccou
     -y
 echo ""
 
+sleep 3s
+
 echo "3) Creating contract..."
 create_res=$(forge create src/tests/ExchangeProxy.sol:ExchangeProxy \
     -r $ETH_URL \
@@ -72,7 +74,8 @@ echo ""
 
 echo "4) Granting authorization..."
 # createDerivativeLimitOrder
-# spend-limit: 1000000 USDT
+# spend-limit: 1000000 USDT (quote-decimals are 0 for this market, as can be 
+# attested by running `injectived q exchange derivative-market $MARKET_ID`)
 # duration: 1 hour
 authorizations="[(8,[(1000000,peggy0xdAC17F958D2ee523a2206206994597C13D831ec7)],3600)]"
 
@@ -131,4 +134,7 @@ grpcurl -plaintext \
     -d '{"subaccount_id":"'$user_subaccount_id'", "market_id":"'$market_id'"}' \
     $GRPC_URL \
     injective.exchange.v1beta1.Query/SubaccountOrders
+echo ""
+
+injectived q authz grants-by-grantee $contract_inj_address
 echo ""

--- a/src/tests/ExchangeProxy.sol
+++ b/src/tests/ExchangeProxy.sol
@@ -26,6 +26,23 @@ contract ExchangeProxy {
         }
     }
 
+    /// @dev Creates multiple derivative limit orders on behalf of the specified sender.
+    /// It will revert with an error if this smart-contract doesn't have a grant 
+    /// from the sender to perform this action on their behalf.
+    /// @param sender The address of the sender.
+    /// @param orders Array of derivative orders to create.
+    /// @return response The response from the batchCreateDerivativeLimitOrders call.
+    function batchCreateDerivativeLimitOrders(
+        address sender,
+        IExchangeModule.DerivativeOrder[] calldata orders
+    ) external returns (IExchangeModule.BatchCreateDerivativeLimitOrdersResponse memory response) {
+        try exchange.batchCreateDerivativeLimitOrders(sender, orders) returns (IExchangeModule.BatchCreateDerivativeLimitOrdersResponse memory resp) {
+            return resp;
+        } catch {
+            revert("error creating derivative limit orders in batch");
+        }
+    }
+
     function queryAllowance(
         address grantee,
         address granter, 


### PR DESCRIPTION
This PR adds a method to the exchange-proxy contract which is used in testing in the injective-core repo

[Main PR](https://github.com/InjectiveLabs/injective-core/pull/2431)
