### PR TITLE
Cp 706/human readable exchange precompile

### DIFF
--- a/demos/exchange-proxy/demo.sh
+++ b/demos/exchange-proxy/demo.sh
@@ -146,17 +146,19 @@ echo ""
 
 echo "5) calling proxy createDerivativeLimitOrder..."
 # create a derivative limit order in INJ/USDT perp market, with:
-# quantity: 1
-# price: 100 USDT / INJ
-# margin: 200 USDT
+# numbers are in API FORMAT, human-readable with 18 decimals
+# Oracle mark price is ~1.461, so use prices close to that
+# quantity 125.75 INJ (125750000000000000000) 
+# price 1.45 USDT (1450000000000000000) - slightly below mark price for buy order
+# margin: 10.5 USDT (10500000000000000000) - notional is 182.3375, min margin ~9.12, using 10.5 for safety
 # Note that the margin, which is roughly the amount that would be taken from the
 # user's deposit if this transaction goes through (aka the "hold"), is covered by
 # the 300 USDT grant created above
 market_id="0x7cc8b10d7deb61e744ef83bdec2bbcf4a056867e89b062c6a453020ca82bd4e4" # INJ/USDT
 user_subaccount_id="$user_eth_address"000000000000000000000001
-quantity=1 
-price=100000000
-margin=200000000 
+quantity=125750000000000000000
+price=1450000000000000000
+margin=10500000000000000000
 fee_recipient='""'
 cid='""'
 order_type="buy"

--- a/src/Exchange.sol
+++ b/src/Exchange.sol
@@ -94,10 +94,10 @@ interface IExchangeModule {
         string subaccountID;
         string marketID;
         bool isLong;
-        uint256 quantity; // API FORMAT: human-readable scaled by 18 decimals (e.g., 5250000000000000000 = 5.25)
-        uint256 entryPrice; // API FORMAT: human-readable scaled by 18 decimals (e.g., 50123450000000000000000 = 50123.45)
-        uint256 margin; // API FORMAT: human-readable scaled by 18 decimals (e.g., 1000750000000000000000 = 1000.75)
-        uint256 cumulativeFundingEntry; // API FORMAT: human-readable scaled by 18 decimals
+        ExchangeTypes.UFixed256x18 quantity; // API FORMAT: human-readable scaled by 18 decimals (e.g., 5250000000000000000 = 5.25)
+        ExchangeTypes.UFixed256x18 entryPrice; // API FORMAT: human-readable scaled by 18 decimals (e.g., 50123450000000000000000 = 50123.45)
+        ExchangeTypes.UFixed256x18 margin; // API FORMAT: human-readable scaled by 18 decimals (e.g., 1000750000000000000000 = 1000.75)
+        ExchangeTypes.UFixed256x18 cumulativeFundingEntry; // API FORMAT: human-readable scaled by 18 decimals
     }
 
     /****************************************************************************

--- a/src/ExchangeTypes.sol
+++ b/src/ExchangeTypes.sol
@@ -2,6 +2,13 @@
 pragma solidity ^0.8.4;
 
 library ExchangeTypes {
+    /// @dev User-defined type representing a fixed-point decimal number with 18 decimal places.
+    /// This type is used for human-readable numeric parameters in exchange precompile order operations,
+    /// allowing values to be specified in API FORMAT (e.g., "1.5" = 1.5 × 10^18 = 1500000000000000000).
+    /// The underlying uint256 stores the value scaled by 10^18 to preserve decimal precision.
+    /// Note: Deposit, withdraw, and transfer operations use CHAIN FORMAT (native token decimals) instead.
+    type UFixed256x18 is uint256;
+
     /// @dev User-defined type for exchange methods that can be approved. This
     /// matches the MsgType type defined in the Exchange authz types.
     type MsgType is uint8;


### PR DESCRIPTION
# Exchange Precompile: Human-Readable Number Formats

This PR goes in conjunction with [this one](https://github.com/InjectiveLabs/injective-core/pull/2500) in the injective-core repo.

## Changes
Introduces standardized number formatting for Exchange precompile
All trading operations now use API format (1e18 scaling)
Balance operations retain chain format (native token decimals)
Added comprehensive documentation and enhanced Solidity interfaces
Includes two complete demos (direct usage + proxy patterns)

## Number Formats

### API Format (Trading Operations)

Human values scaled by 1e18
Used for: orders, positions, margins

Examples:
Price 1.05 → 1050000000000000000
Margin 500.25 → 500250000000000000000
Chain Format (Balance Operations)

### Native token decimal precision

Used for: deposits, transfers, balance queries

Examples:
1 USDT (6 decimals) → 1000000
1 INJ (18 decimals) → 1000000000000000000


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved demo error handling with clearer failure messages and transaction tracing on errors.

* **Documentation**
  * Added API-format notes and explanatory comments clarifying 18-decimal fixed-point semantics and margin/quantity rationale.

* **API / Behavior**
  * Public numeric fields, inputs and example payloads now use 18-decimal fixed-point (API-format) values; demos and sample orders updated to match.
* **Other**
  * Introduced an explicit 18-decimal fixed-point numeric type for API-facing amounts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->