### PR TITLE
[IC-960] implement an oracle precompile

### DIFF
--- a/docs/oracle_precompile.md
+++ b/docs/oracle_precompile.md
@@ -1,0 +1,105 @@
+# Oracle Precompile
+
+## Overview
+
+The Oracle precompile exposes on-chain reference prices to native EVM contracts.
+It is read-only and supports all active oracle types on the Injective chain.
+
+| Property | Value |
+|----------|-------|
+| Address  | `0x0000000000000000000000000000000000000067` |
+| Interface | `IOracleModule` (see `src/Oracle.sol`) |
+
+## Interface
+
+```solidity
+interface IOracleModule {
+    function oraclePrice(
+        uint8 oracleType,
+        string calldata base,
+        string calldata quote
+    ) external view returns (uint256 price);
+}
+```
+
+## Price scale
+
+All returned prices are **1e18-scaled unsigned integers** (the raw mantissa of
+Injective's internal `LegacyDec` type).  Divide by `1e18` in fixed-point
+arithmetic to obtain the human-readable decimal value.
+
+```solidity
+uint256 constant PRICE_SCALE = 1e18;
+uint256 rawPrice = oracle.oraclePrice(2, "BTC", "USD");
+// rawPrice / PRICE_SCALE ≈ the BTC/USD spot price as a decimal
+```
+
+## Oracle type values
+
+| Value | Oracle type | Notes |
+|-------|-------------|-------|
+| 2  | PriceFeed  | |
+| 3  | Coinbase   | |
+| 9  | Pyth       | `base` is a 0x-prefixed 32-byte price-id hex string |
+| 11 | Provider   | `base` is the asset symbol; `quote` is the provider name |
+| 12 | Stork      | |
+| 13 | ChainlinkDataStreams | |
+| 1  | Band       | **Deprecated** — always reverts |
+| 4  | Chainlink  | **Deprecated** — always reverts |
+| 10 | BandIBC    | **Deprecated** — always reverts |
+
+## Key conventions
+
+### PriceFeed / Coinbase / Stork / ChainlinkDataStreams
+
+```
+base  = asset symbol, e.g. "BTC"
+quote = quote symbol, e.g. "USD"
+```
+
+### Pyth
+
+```
+base  = 0x-prefixed 32-byte price-id (hex), e.g. "0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43"
+quote = "USD"   (Pyth always quotes in USD)
+```
+
+### Provider
+
+Provider oracle keys follow the compound-key convention used by the Injective
+oracle module.  The `base` field may be a plain symbol or a compound key
+produced by `JoinProviderCompoundKey`, and `quote` is always the provider name.
+
+```
+base  = asset symbol or compound key
+quote = provider name, e.g. "prov1"
+```
+
+## Error behaviour
+
+The call reverts with an `OraclePriceNotFound` error when:
+
+- No price has been posted for the requested `(oracleType, base, quote)` triple.
+- A deprecated oracle type (Band=1, Chainlink=4, BandIBC=10) is requested.
+- An unrecognised `oracleType` value is passed.
+
+## Example usage
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./Oracle.sol";
+
+contract PriceConsumer {
+    IOracleModule constant oracle =
+        IOracleModule(0x0000000000000000000000000000000000000067);
+
+    uint256 constant PRICE_SCALE = 1e18;
+
+    /// @return The BTC/USD price with 18-decimal precision, scaled by 1e18.
+    function getBtcUsdPrice() external view returns (uint256) {
+        return oracle.oraclePrice(2 /* PriceFeed */, "BTC", "USD");
+    }
+}
+```

--- a/docs/oracle_precompile.md
+++ b/docs/oracle_precompile.md
@@ -14,11 +14,35 @@ It is read-only and supports all active oracle types on the Injective chain.
 
 ```solidity
 interface IOracleModule {
+    struct PricePairState {
+        uint256 pairPrice;
+        uint256 basePrice;
+        uint256 quotePrice;
+        uint256 baseCumulativePrice;
+        uint256 quoteCumulativePrice;
+        uint64  baseTimestamp;
+        uint64  quoteTimestamp;
+    }
+
     function oraclePrice(
         uint8 oracleType,
         string calldata base,
         string calldata quote
     ) external view returns (uint256 price);
+
+    function oraclePricePairState(
+        uint8 oracleType,
+        string calldata base,
+        string calldata quote
+    ) external view returns (PricePairState memory state);
+
+    function oraclePricePairStateScaled(
+        uint8 oracleType,
+        string calldata base,
+        string calldata quote,
+        uint32 baseDecimals,
+        uint32 quoteDecimals
+    ) external view returns (PricePairState memory state);
 }
 ```
 
@@ -75,15 +99,74 @@ base  = asset symbol or compound key
 quote = provider name, e.g. "prov1"
 ```
 
+## Methods
+
+### `oraclePrice`
+
+Returns only the pair price as a `uint256` scalar.  Sufficient for simple price
+consumers that do not need timestamps or per-leg prices.
+
+### `oraclePricePairState`
+
+Returns the full `PricePairState` struct:
+
+| Field | Description |
+|-------|-------------|
+| `pairPrice` | base/quote ratio, 1e18 scaled |
+| `basePrice` | raw base-leg spot price, 1e18 scaled |
+| `quotePrice` | raw quote-leg spot price, 1e18 scaled; **0** when `quote == "USD"` |
+| `baseCumulativePrice` | cumulative base price for TWAP computation, 1e18 scaled |
+| `quoteCumulativePrice` | cumulative quote price for TWAP computation, 1e18 scaled; **0** when `quote == "USD"` |
+| `baseTimestamp` | Unix seconds of the most recent base-leg update |
+| `quoteTimestamp` | Unix seconds of the most recent quote-leg update; **== baseTimestamp** when `quote == "USD"` |
+
+Use this method when you need the update timestamp (e.g. for a Chainlink
+`latestRoundData()` `updatedAt` field) or individual leg prices.
+
+### `oraclePricePairStateScaled`
+
+Same as `oraclePricePairState` but applies explicit decimal scaling to
+`pairPrice`:
+
+```
+pairPrice = baseRate * 10^quoteDecimals / (quoteRate * 10^baseDecimals)
+```
+
+**Allowed only when:**
+- `oracleType != PriceFeed (2)`
+- `quote != "USD"`
+
+Any other combination reverts with `OraclePriceNotFound`.
+
+The individual leg prices (`basePrice`, `quotePrice`), cumulative prices, and
+timestamps are **not** rescaled; only `pairPrice` is affected.
+
+## USD-quote zero-fill convention
+
+When `quote == "USD"`, the on-chain oracle module uses a single-leg price state
+(there is no quote-side price feed for USD itself).  The precompile reflects this:
+
+- `quotePrice` and `quoteCumulativePrice` are **0**
+- `quoteTimestamp` is set to **`baseTimestamp`**
+
+Callers building a `latestRoundData()` implementation should use
+`min(baseTimestamp, quoteTimestamp)` as `updatedAt`, which collapses to
+`baseTimestamp` for USD pairs.
+
 ## Error behaviour
 
-The call reverts with an `OraclePriceNotFound` error when:
+All methods revert with an `OraclePriceNotFound` error when:
 
 - No price has been posted for the requested `(oracleType, base, quote)` triple.
 - A deprecated oracle type (Band=1, Chainlink=4, BandIBC=10) is requested.
 - An unrecognised `oracleType` value is passed.
+- `oraclePricePairStateScaled` is called with `oracleType == PriceFeed` or `quote == "USD"`.
 
-## Example usage
+## Example: Chainlink AggregatorV3Interface wrapper
+
+The following example demonstrates how to wrap the precompile to implement
+Chainlink's `latestRoundData()`.  This covers the majority of Chainlink
+consumers (Aave v3, Morpho, etc.) that only call `latestRoundData()`.
 
 ```solidity
 // SPDX-License-Identifier: MIT
@@ -91,15 +174,87 @@ pragma solidity ^0.8.20;
 
 import "./Oracle.sol";
 
-contract PriceConsumer {
-    IOracleModule constant oracle =
+/// @notice Minimal Chainlink AggregatorV3Interface implementation backed by
+///         the Injective oracle precompile.
+///
+/// @dev Deploy one instance per market pair.  Constructor arguments:
+///        oracleType_  — numeric oracle type (e.g. 2 for PriceFeed)
+///        base_        — base asset symbol (e.g. "BTC")
+///        quote_       — quote asset symbol (e.g. "USD")
+///        decimals_    — number of decimals to report (e.g. 8)
+///
+///      The precompile returns prices as 1e18-scaled uint256 values.  This
+///      wrapper rescales to the declared decimals_ precision.
+contract InjectiveChainlinkFeed {
+    IOracleModule constant ORACLE =
         IOracleModule(0x0000000000000000000000000000000000000067);
 
     uint256 constant PRICE_SCALE = 1e18;
 
-    /// @return The BTC/USD price with 18-decimal precision, scaled by 1e18.
-    function getBtcUsdPrice() external view returns (uint256) {
-        return oracle.oraclePrice(2 /* PriceFeed */, "BTC", "USD");
+    uint8 public immutable decimals;
+    string public description;
+
+    uint8  private immutable _oracleType;
+    string private _base;
+    string private _quote;
+
+    constructor(
+        uint8  oracleType_,
+        string memory base_,
+        string memory quote_,
+        uint8  decimals_,
+        string memory description_
+    ) {
+        _oracleType  = oracleType_;
+        _base        = base_;
+        _quote       = quote_;
+        decimals     = decimals_;
+        description  = description_;
+    }
+
+    function version() external pure returns (uint256) { return 1; }
+
+    /// @notice Returns the latest price data in Chainlink format.
+    ///
+    /// @dev roundId and answeredInRound are derived from updatedAt (unix
+    ///      seconds) as a stable monotonic approximation.  Two updates within
+    ///      the same second produce the same roundId; this is acceptable for
+    ///      the use-cases this wrapper targets.
+    function latestRoundData()
+        external
+        view
+        returns (
+            uint80  roundId,
+            int256  answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80  answeredInRound
+        )
+    {
+        IOracleModule.PricePairState memory state =
+            ORACLE.oraclePricePairState(_oracleType, _base, _quote);
+
+        // Rescale from 1e18 to the declared decimals precision.
+        uint256 scaledPrice =
+            state.pairPrice * (10 ** uint256(decimals)) / PRICE_SCALE;
+
+        // Use the stalest leg's timestamp as updatedAt.
+        updatedAt = state.baseTimestamp < state.quoteTimestamp
+            ? state.baseTimestamp
+            : state.quoteTimestamp;
+
+        roundId        = uint80(updatedAt);
+        answer         = int256(scaledPrice);
+        startedAt      = updatedAt;
+        answeredInRound = roundId;
+    }
+
+    function getRoundData(uint80)
+        external
+        pure
+        returns (uint80, int256, uint256, uint256, uint80)
+    {
+        revert("historical rounds not supported");
     }
 }
 ```

--- a/src/Oracle.sol
+++ b/src/Oracle.sol
@@ -5,6 +5,38 @@ pragma solidity ^0.8.20;
 /// @notice Read-only access to the on-chain oracle reference prices.
 /// @dev Deployed at 0x0000000000000000000000000000000000000067
 interface IOracleModule {
+    /// @notice Full price-pair state returned by oraclePricePairState and
+    ///         oraclePricePairStateScaled.
+    ///
+    /// @dev All price and cumulative-price fields are 1e18-scaled unsigned
+    ///      integers (raw LegacyDec mantissas).  Divide by 1e18 to obtain the
+    ///      human-readable decimal value.
+    ///
+    ///      When `quote == "USD"` (single-leg oracle path):
+    ///        - quotePrice            == 0
+    ///        - quoteCumulativePrice  == 0
+    ///        - quoteTimestamp        == baseTimestamp
+    ///
+    ///      This matches the on-chain PricePairStateForUSD semantics.
+    struct PricePairState {
+        /// @notice base/quote ratio, 1e18 scaled.
+        uint256 pairPrice;
+        /// @notice Raw base-leg spot price, 1e18 scaled.
+        uint256 basePrice;
+        /// @notice Raw quote-leg spot price, 1e18 scaled.  Zero when quote == "USD".
+        uint256 quotePrice;
+        /// @notice Cumulative base price used for TWAP computation, 1e18 scaled.
+        uint256 baseCumulativePrice;
+        /// @notice Cumulative quote price used for TWAP computation, 1e18 scaled.
+        ///         Zero when quote == "USD".
+        uint256 quoteCumulativePrice;
+        /// @notice Unix seconds of the most recent base-leg price update.
+        uint64 baseTimestamp;
+        /// @notice Unix seconds of the most recent quote-leg price update.
+        ///         Equal to baseTimestamp when quote == "USD".
+        uint64 quoteTimestamp;
+    }
+
     /// @notice Returns the reference price for a (oracleType, base, quote) triple.
     ///
     /// @dev All prices are returned as unsigned integers scaled by 1e18 (i.e. the raw
@@ -42,4 +74,61 @@ interface IOracleModule {
         string calldata base,
         string calldata quote
     ) external view returns (uint256 price);
+
+    /// @notice Returns the full price-pair state for a (oracleType, base, quote) triple.
+    ///
+    /// @dev The returned struct includes pair price, individual leg prices, cumulative
+    ///      prices for TWAP computation, and per-leg timestamps.  All price values are
+    ///      1e18-scaled unsigned integers.
+    ///
+    ///      Recommended for Chainlink AggregatorV3Interface and Pyth PythAggregatorV3
+    ///      wrapper contracts, where latestRoundData() requires both the price and a
+    ///      timestamp (updatedAt).
+    ///
+    ///      Oracle type conventions are the same as oraclePrice().
+    ///
+    ///      When quote == "USD" the quotePrice, quoteCumulativePrice are returned as 0
+    ///      and quoteTimestamp equals baseTimestamp (single-leg path, no quote-side data).
+    ///
+    /// @param oracleType Numeric oracle-type enum value.
+    /// @param base       Base asset identifier.
+    /// @param quote      Quote asset identifier.
+    /// @return state     Full price-pair state.  Reverts if no price is available.
+    function oraclePricePairState(
+        uint8 oracleType,
+        string calldata base,
+        string calldata quote
+    ) external view returns (PricePairState memory state);
+
+    /// @notice Returns the full price-pair state with explicit decimal scaling.
+    ///
+    /// @dev Equivalent to oraclePricePairState() but applies decimal scaling to the
+    ///      pair price:
+    ///
+    ///        pairPrice = baseRate * 10^quoteDecimals / (quoteRate * 10^baseDecimals)
+    ///
+    ///      This matches the ScalingOptions behaviour of the on-chain oracle module.
+    ///
+    ///      Scaling is only valid when:
+    ///        - oracleType != PriceFeed (2)
+    ///        - quote != "USD"
+    ///      Any other combination reverts with OraclePriceNotFound.
+    ///
+    ///      The basePrice, quotePrice, cumulative, and timestamp fields are not
+    ///      affected by scaling; only pairPrice is rescaled.
+    ///
+    /// @param oracleType   Numeric oracle-type enum value.
+    /// @param base         Base asset identifier.
+    /// @param quote        Quote asset identifier (must not be "USD").
+    /// @param baseDecimals Decimal precision of the base asset.
+    /// @param quoteDecimals Decimal precision of the quote asset.
+    /// @return state       Full price-pair state with scaled pairPrice.  Reverts if
+    ///                     no price is available or the combination is not allowed.
+    function oraclePricePairStateScaled(
+        uint8 oracleType,
+        string calldata base,
+        string calldata quote,
+        uint32 baseDecimals,
+        uint32 quoteDecimals
+    ) external view returns (PricePairState memory state);
 }

--- a/src/Oracle.sol
+++ b/src/Oracle.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title Injective Oracle precompile
+/// @notice Read-only access to the on-chain oracle reference prices.
+/// @dev Deployed at 0x0000000000000000000000000000000000000067
+interface IOracleModule {
+    /// @notice Returns the reference price for a (oracleType, base, quote) triple.
+    ///
+    /// @dev All prices are returned as unsigned integers scaled by 1e18 (i.e. the raw
+    /// mantissa of the underlying `LegacyDec` value). Divide by 1e18 to obtain the
+    /// human-readable decimal price.
+    ///
+    /// Supported oracleType values:
+    ///   2  = PriceFeed
+    ///   3  = Coinbase
+    ///   9  = Pyth
+    ///   11 = Provider
+    ///   12 = Stork
+    ///   13 = ChainlinkDataStreams
+    ///
+    /// Deprecated / unsupported types (1=Band, 4=Chainlink, 10=BandIBC) will
+    /// cause a revert with an OraclePriceNotFound error.
+    ///
+    /// Key conventions per oracle type:
+    ///   PriceFeed / Coinbase / Stork / ChainlinkDataStreams:
+    ///     base  = asset symbol (e.g. "BTC")
+    ///     quote = quote symbol or "USD"
+    ///   Pyth:
+    ///     base  = 0x-prefixed 32-byte price-id hex string
+    ///     quote = "USD" (Pyth always quotes in USD)
+    ///   Provider:
+    ///     base  = asset symbol (or compound key from JoinProviderCompoundKey)
+    ///     quote = provider name (e.g. "prov1")
+    ///
+    /// @param oracleType Numeric oracle-type enum value (see above).
+    /// @param base       Base asset identifier (oracle-type–dependent, see above).
+    /// @param quote      Quote asset identifier (oracle-type–dependent, see above).
+    /// @return price     Reference price scaled by 1e18.  Reverts if no price is available.
+    function oraclePrice(
+        uint8 oracleType,
+        string calldata base,
+        string calldata quote
+    ) external view returns (uint256 price);
+}

--- a/src/tests/OracleTest.sol
+++ b/src/tests/OracleTest.sol
@@ -35,4 +35,62 @@ contract OracleTest {
         require(success, "staticcall failed");
         price = abi.decode(result, (uint256));
     }
+
+    /// @dev Calls oraclePricePairState via a regular CALL.
+    function oraclePricePairState(
+        uint8 oracleType,
+        string memory base,
+        string memory quote
+    ) external view returns (IOracleModule.PricePairState memory) {
+        return oracle.oraclePricePairState(oracleType, base, quote);
+    }
+
+    /// @dev Calls oraclePricePairState via an explicit STATICCALL.
+    function oraclePricePairStateViaStaticCall(
+        uint8 oracleType,
+        string memory base,
+        string memory quote
+    ) external view returns (IOracleModule.PricePairState memory state) {
+        bytes memory data = abi.encodeWithSelector(
+            IOracleModule.oraclePricePairState.selector,
+            oracleType,
+            base,
+            quote
+        );
+        (bool success, bytes memory result) = oracleContract.staticcall(data);
+        require(success, "staticcall failed");
+        state = abi.decode(result, (IOracleModule.PricePairState));
+    }
+
+    /// @dev Calls oraclePricePairStateScaled via a regular CALL.
+    function oraclePricePairStateScaled(
+        uint8 oracleType,
+        string memory base,
+        string memory quote,
+        uint32 baseDecimals,
+        uint32 quoteDecimals
+    ) external view returns (IOracleModule.PricePairState memory) {
+        return oracle.oraclePricePairStateScaled(oracleType, base, quote, baseDecimals, quoteDecimals);
+    }
+
+    /// @dev Calls oraclePricePairStateScaled via an explicit STATICCALL.
+    function oraclePricePairStateScaledViaStaticCall(
+        uint8 oracleType,
+        string memory base,
+        string memory quote,
+        uint32 baseDecimals,
+        uint32 quoteDecimals
+    ) external view returns (IOracleModule.PricePairState memory state) {
+        bytes memory data = abi.encodeWithSelector(
+            IOracleModule.oraclePricePairStateScaled.selector,
+            oracleType,
+            base,
+            quote,
+            baseDecimals,
+            quoteDecimals
+        );
+        (bool success, bytes memory result) = oracleContract.staticcall(data);
+        require(success, "staticcall failed");
+        state = abi.decode(result, (IOracleModule.PricePairState));
+    }
 }

--- a/src/tests/OracleTest.sol
+++ b/src/tests/OracleTest.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >0.6.6;
+
+import "../Oracle.sol";
+
+/// @dev Thin wrapper used by Go integration tests.
+///      Forwards calls to the oracle precompile at address 0x67.
+contract OracleTest {
+    address constant oracleContract = 0x0000000000000000000000000000000000000067;
+    IOracleModule oracle = IOracleModule(oracleContract);
+
+    /// @dev Calls the precompile via a regular CALL (non-static context).
+    function oraclePrice(
+        uint8 oracleType,
+        string memory base,
+        string memory quote
+    ) external view returns (uint256) {
+        return oracle.oraclePrice(oracleType, base, quote);
+    }
+
+    /// @dev Calls the precompile via an explicit STATICCALL, exercising the
+    ///      read-only execution path.
+    function oraclePriceViaStaticCall(
+        uint8 oracleType,
+        string memory base,
+        string memory quote
+    ) external view returns (uint256 price) {
+        bytes memory data = abi.encodeWithSelector(
+            IOracleModule.oraclePrice.selector,
+            oracleType,
+            base,
+            quote
+        );
+        (bool success, bytes memory result) = oracleContract.staticcall(data);
+        require(success, "staticcall failed");
+        price = abi.decode(result, (uint256));
+    }
+}


### PR DESCRIPTION
add IOracleModule interface and docs for Injective oracle precompile
- Add the Solidity surface for the Injective-chain oracle EVM precompile at 0x0000000000000000000000000000000000000067.
- src/Oracle.sol: IOracleModule with oraclePrice(uint8, string, string) returning a 1e18-scaled uint256; NatSpec describes oracle types and Provider (base = symbol, quote = provider name) semantics.
- src/tests/OracleTest.sol: thin wrapper for integration tests (CALL and staticcall paths).
- docs/oracle_precompile.md: usage, address, and conventions.

add IOracleModule PricePairState and pair-state methods
- Define PricePairState in Oracle.sol; add oraclePricePairState and oraclePricePairStateScaled (with baseDecimals/quoteDecimals) next to oraclePrice. Update OracleTest wrappers and oracle_precompile.md (scaling gate, USD-quote zero-fill, Chainlink wrapper example).

Solves [IC-960](https://linear.app/injectivelabs/issue/IC-960/implement-an-oracle-precompile)

The changes in this PR are required for https://github.com/InjectiveLabs/injective-core/pull/2785

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Oracle precompile interface for querying on-chain reference prices
  * Support for multiple oracle types with flexible price pair queries and decimal scaling
  * Includes example Chainlink-compatible wrapper contract

* **Documentation**
  * Added oracle precompile documentation with API reference and integration examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->