### PR TITLE
[ic-1040][oracle] provide wrapper contracts for Pyth and Morpho

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ out/
 .DS_Store
 node_modules
 .injectived
+.idea

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,10 @@
 [submodule "lib/openzeppelin-contracts-upgradeable"]
 	path = lib/openzeppelin-contracts-upgradeable
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable
+[submodule "lib/pyth-crosschain"]
+	path = lib/pyth-crosschain
+	url = https://github.com/pyth-network/pyth-crosschain
+	branch = main
+[submodule "lib/morpho-blue-oracles"]
+	path = lib/morpho-blue-oracles
+	url = https://github.com/morpho-org/morpho-blue-oracles

--- a/foundry.lock
+++ b/foundry.lock
@@ -5,10 +5,22 @@
   "lib/layerzero-v2": {
     "rev": "88428755be6caa71cb1d2926141d73c8989296b5"
   },
+  "lib/morpho-blue-oracles": {
+    "tag": {
+      "name": "v2.0.0",
+      "rev": "07a9a6988b0e1b316ac2fa97ec62ad485fbd0041"
+    }
+  },
   "lib/openzeppelin-contracts": {
     "rev": "e4f70216d759d8e6a64144a9e1f7bbeed78e7079"
   },
   "lib/openzeppelin-contracts-upgradeable": {
     "rev": "e725abddf1e01cf05ace496e950fc8e243cc7cab"
+  },
+  "lib/pyth-crosschain": {
+    "branch": {
+      "name": "main",
+      "rev": "8ac676d7facb3e92b9c1529beda586fa1c4699b3"
+    }
   }
 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -10,6 +10,8 @@ remappings = [
   '@layerzerolabs/lz-evm-protocol-v2/=lib/layerzero-v2/packages/layerzero-v2/evm/protocol',
   '@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/',
   '@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/',
+  'morpho-blue-oracles/=lib/morpho-blue-oracles/',
+  'pyth-crosschain/=lib/pyth-crosschain/',
 ]
 
 [rpc_endpoints]

--- a/src/InjectiveAggregatorV3.sol
+++ b/src/InjectiveAggregatorV3.sol
@@ -16,7 +16,7 @@ import {AggregatorV3Interface} from "morpho-blue-oracles/src/morpho-chainlink/in
 /// Historical Chainlink rounds are not stored. Any round-based read is served
 /// from the latest precompile snapshot because the underlying oracle module
 /// exposes latest state, not per-round history.
-contract InjectiveMorphoAggregatorV3 is AggregatorV3Interface {
+contract InjectiveAggregatorV3 is AggregatorV3Interface {
     IOracleModule internal constant ORACLE = IOracleModule(0x0000000000000000000000000000000000000067);
 
     uint256 internal constant MAX_INT256 = uint256(type(int256).max);

--- a/src/InjectiveMorphoAggregatorV3.sol
+++ b/src/InjectiveMorphoAggregatorV3.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+
+import {IOracleModule} from "./Oracle.sol";
+import {AggregatorV3Interface} from "morpho-blue-oracles/src/morpho-chainlink/interfaces/AggregatorV3Interface.sol";
+
+/// @notice Morpho-facing AggregatorV3 wrapper backed by the Injective oracle
+/// precompile.
+///
+/// @dev This contract is meant to satisfy Morpho's
+/// `AggregatorV3Interface` dependency. It exposes only the standard
+/// Chainlink-compatible surface that Morpho consumes.
+contract InjectiveMorphoAggregatorV3 is AggregatorV3Interface {
+    IOracleModule internal constant ORACLE =
+        IOracleModule(0x0000000000000000000000000000000000000067);
+
+    uint256 internal constant PRECOMPILE_PRICE_SCALE = 1e18;
+    uint256 internal constant ADAPTER_VERSION = 1;
+
+    uint8 public immutable override decimals;
+    uint8 public immutable oracleType;
+    string public override description;
+    string public base;
+    string public quote;
+
+    constructor(
+        uint8 oracleType_,
+        string memory base_,
+        string memory quote_,
+        uint8 decimals_,
+        string memory description_
+    ) {
+        oracleType = oracleType_;
+        decimals = decimals_;
+        description = description_;
+        base = base_;
+        quote = quote_;
+    }
+
+    function version() external pure override returns (uint256) {
+        return ADAPTER_VERSION;
+    }
+
+    function getRoundData(
+        uint80 roundId
+    )
+        external
+        view
+        override
+        returns (
+            uint80 returnedRoundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        )
+    {
+        IOracleModule.PricePairState memory state = _latestState();
+        updatedAt = _updatedAt(state);
+        answer = _scaledAnswer(state.pairPrice);
+
+        return (roundId, answer, updatedAt, updatedAt, roundId);
+    }
+
+    function latestRoundData()
+        external
+        view
+        override
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        )
+    {
+        IOracleModule.PricePairState memory state = _latestState();
+        updatedAt = _updatedAt(state);
+        // forge-lint: disable-next-line(unsafe-typecast)
+        roundId = uint80(updatedAt);
+        answer = _scaledAnswer(state.pairPrice);
+
+        return (roundId, answer, updatedAt, updatedAt, roundId);
+    }
+
+    function _latestState() internal view returns (IOracleModule.PricePairState memory) {
+        return ORACLE.oraclePricePairState(oracleType, base, quote);
+    }
+
+    function _updatedAt(
+        IOracleModule.PricePairState memory state
+    ) internal pure returns (uint256) {
+        return state.baseTimestamp < state.quoteTimestamp ? state.baseTimestamp : state.quoteTimestamp;
+    }
+
+    function _scaledAnswer(uint256 pairPrice) internal view returns (int256) {
+        uint256 scaledPrice = Math.mulDiv(pairPrice, 10 ** uint256(decimals), PRECOMPILE_PRICE_SCALE);
+        require(scaledPrice <= uint256(type(int256).max), "answer overflow");
+        // forge-lint: disable-next-line(unsafe-typecast)
+        return int256(scaledPrice);
+    }
+}

--- a/src/InjectiveMorphoAggregatorV3.sol
+++ b/src/InjectiveMorphoAggregatorV3.sol
@@ -12,6 +12,10 @@ import {AggregatorV3Interface} from "morpho-blue-oracles/src/morpho-chainlink/in
 /// @dev This contract is meant to satisfy Morpho's
 /// `AggregatorV3Interface` dependency. It exposes only the standard
 /// Chainlink-compatible surface that Morpho consumes.
+///
+/// Historical Chainlink rounds are not stored. Any round-based read is served
+/// from the latest precompile snapshot because the underlying oracle module
+/// exposes latest state, not per-round history.
 contract InjectiveMorphoAggregatorV3 is AggregatorV3Interface {
     IOracleModule internal constant ORACLE = IOracleModule(0x0000000000000000000000000000000000000067);
 
@@ -51,6 +55,9 @@ contract InjectiveMorphoAggregatorV3 is AggregatorV3Interface {
         override
         returns (uint80 returnedRoundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
     {
+        // Partial AggregatorV3 emulation: return the latest snapshot and echo
+        // the caller-provided round id, since no historical round storage
+        // exists behind the precompile.
         (answer, updatedAt) = _latestAnswerAndTimestamp();
         return (roundId, answer, updatedAt, updatedAt, roundId);
     }

--- a/src/InjectiveMorphoAggregatorV3.sol
+++ b/src/InjectiveMorphoAggregatorV3.sol
@@ -51,7 +51,8 @@ contract InjectiveMorphoAggregatorV3 is AggregatorV3Interface {
         override
         returns (uint80 returnedRoundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
     {
-        return _roundData(roundId);
+        (answer, updatedAt) = _latestAnswerAndTimestamp();
+        return (roundId, answer, updatedAt, updatedAt, roundId);
     }
 
     function latestRoundData()
@@ -60,40 +61,16 @@ contract InjectiveMorphoAggregatorV3 is AggregatorV3Interface {
         override
         returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
     {
-        IOracleModule.PricePairState memory state = _latestState();
-        updatedAt = _updatedAt(state);
+        (answer, updatedAt) = _latestAnswerAndTimestamp();
         // forge-lint: disable-next-line(unsafe-typecast)
         roundId = uint80(updatedAt);
-        return _roundData(roundId, state, updatedAt);
-    }
-
-    function _roundData(uint80 roundId)
-        internal
-        view
-        returns (uint80 returnedRoundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
-    {
-        IOracleModule.PricePairState memory state = _latestState();
-        updatedAt = _updatedAt(state);
-        return _roundData(roundId, state, updatedAt);
-    }
-
-    function _roundData(uint80 roundId, IOracleModule.PricePairState memory state, uint256 updatedAt)
-        internal
-        view
-        returns (
-            uint80 returnedRoundId,
-            int256 answer,
-            uint256 startedAt,
-            uint256 returnedUpdatedAt,
-            uint80 answeredInRound
-        )
-    {
-        answer = _scaledAnswer(state.pairPrice);
         return (roundId, answer, updatedAt, updatedAt, roundId);
     }
 
-    function _latestState() internal view returns (IOracleModule.PricePairState memory) {
-        return ORACLE.oraclePricePairState(oracleType, base, quote);
+    function _latestAnswerAndTimestamp() internal view returns (int256 answer, uint256 updatedAt) {
+        IOracleModule.PricePairState memory state = ORACLE.oraclePricePairState(oracleType, base, quote);
+        updatedAt = _updatedAt(state);
+        answer = _scaledAnswer(state.pairPrice);
     }
 
     function _updatedAt(IOracleModule.PricePairState memory state) internal pure returns (uint256) {

--- a/src/InjectiveMorphoAggregatorV3.sol
+++ b/src/InjectiveMorphoAggregatorV3.sol
@@ -13,17 +13,19 @@ import {AggregatorV3Interface} from "morpho-blue-oracles/src/morpho-chainlink/in
 /// `AggregatorV3Interface` dependency. It exposes only the standard
 /// Chainlink-compatible surface that Morpho consumes.
 contract InjectiveMorphoAggregatorV3 is AggregatorV3Interface {
-    IOracleModule internal constant ORACLE =
-        IOracleModule(0x0000000000000000000000000000000000000067);
+    IOracleModule internal constant ORACLE = IOracleModule(0x0000000000000000000000000000000000000067);
 
+    uint256 internal constant MAX_INT256 = uint256(type(int256).max);
     uint256 internal constant PRECOMPILE_PRICE_SCALE = 1e18;
     uint256 internal constant ADAPTER_VERSION = 1;
 
-    uint8 public immutable override decimals;
     uint8 public immutable oracleType;
+    uint8 public immutable override decimals;
     string public override description;
     string public base;
     string public quote;
+
+    error AnswerOverflow();
 
     constructor(
         uint8 oracleType_,
@@ -43,45 +45,50 @@ contract InjectiveMorphoAggregatorV3 is AggregatorV3Interface {
         return ADAPTER_VERSION;
     }
 
-    function getRoundData(
-        uint80 roundId
-    )
+    function getRoundData(uint80 roundId)
         external
         view
         override
-        returns (
-            uint80 returnedRoundId,
-            int256 answer,
-            uint256 startedAt,
-            uint256 updatedAt,
-            uint80 answeredInRound
-        )
+        returns (uint80 returnedRoundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
     {
-        IOracleModule.PricePairState memory state = _latestState();
-        updatedAt = _updatedAt(state);
-        answer = _scaledAnswer(state.pairPrice);
-
-        return (roundId, answer, updatedAt, updatedAt, roundId);
+        return _roundData(roundId);
     }
 
     function latestRoundData()
         external
         view
         override
-        returns (
-            uint80 roundId,
-            int256 answer,
-            uint256 startedAt,
-            uint256 updatedAt,
-            uint80 answeredInRound
-        )
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
     {
         IOracleModule.PricePairState memory state = _latestState();
         updatedAt = _updatedAt(state);
         // forge-lint: disable-next-line(unsafe-typecast)
         roundId = uint80(updatedAt);
-        answer = _scaledAnswer(state.pairPrice);
+        return _roundData(roundId, state, updatedAt);
+    }
 
+    function _roundData(uint80 roundId)
+        internal
+        view
+        returns (uint80 returnedRoundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+    {
+        IOracleModule.PricePairState memory state = _latestState();
+        updatedAt = _updatedAt(state);
+        return _roundData(roundId, state, updatedAt);
+    }
+
+    function _roundData(uint80 roundId, IOracleModule.PricePairState memory state, uint256 updatedAt)
+        internal
+        view
+        returns (
+            uint80 returnedRoundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 returnedUpdatedAt,
+            uint80 answeredInRound
+        )
+    {
+        answer = _scaledAnswer(state.pairPrice);
         return (roundId, answer, updatedAt, updatedAt, roundId);
     }
 
@@ -89,15 +96,13 @@ contract InjectiveMorphoAggregatorV3 is AggregatorV3Interface {
         return ORACLE.oraclePricePairState(oracleType, base, quote);
     }
 
-    function _updatedAt(
-        IOracleModule.PricePairState memory state
-    ) internal pure returns (uint256) {
+    function _updatedAt(IOracleModule.PricePairState memory state) internal pure returns (uint256) {
         return state.baseTimestamp < state.quoteTimestamp ? state.baseTimestamp : state.quoteTimestamp;
     }
 
     function _scaledAnswer(uint256 pairPrice) internal view returns (int256) {
         uint256 scaledPrice = Math.mulDiv(pairPrice, 10 ** uint256(decimals), PRECOMPILE_PRICE_SCALE);
-        require(scaledPrice <= uint256(type(int256).max), "answer overflow");
+        if (scaledPrice > MAX_INT256) revert AnswerOverflow();
         // forge-lint: disable-next-line(unsafe-typecast)
         return int256(scaledPrice);
     }

--- a/src/InjectivePyth.sol
+++ b/src/InjectivePyth.sol
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+
+import {IOracleModule} from "./Oracle.sol";
+import {IPyth} from "pyth-crosschain/target_chains/ethereum/sdk/solidity/IPyth.sol";
+import {PythErrors} from "pyth-crosschain/target_chains/ethereum/sdk/solidity/PythErrors.sol";
+import {PythStructs} from "pyth-crosschain/target_chains/ethereum/sdk/solidity/PythStructs.sol";
+
+/// @notice Pyth IPyth-compatible wrapper backed by the Injective oracle
+/// precompile.
+///
+/// @dev This adapter is intentionally feed-specific. It exists to satisfy the
+/// official `PythAggregatorV3` contract, which expects an `IPyth` contract plus
+/// a `priceId`.
+contract InjectivePyth is IPyth {
+    IOracleModule internal constant ORACLE =
+        IOracleModule(0x0000000000000000000000000000000000000067);
+
+    uint8 internal constant PYTH_ORACLE_TYPE = 9;
+    uint256 internal constant PRECOMPILE_PRICE_SCALE = 1e18;
+
+    bytes32 public immutable FEED_ID;
+    uint8 public immutable FEED_DECIMALS;
+    uint8 public immutable SOURCE_ORACLE_TYPE;
+    string public sourceBase;
+    string public sourceQuote;
+
+    error UnsupportedPythMethod();
+
+    constructor(
+        bytes32 feedId_,
+        uint8 sourceOracleType_,
+        string memory sourceBase_,
+        string memory sourceQuote_,
+        uint8 feedDecimals_
+    ) {
+        FEED_ID = feedId_;
+        FEED_DECIMALS = feedDecimals_;
+        SOURCE_ORACLE_TYPE = sourceOracleType_;
+
+        if (sourceOracleType_ == PYTH_ORACLE_TYPE && bytes(sourceBase_).length == 0) {
+            sourceBase = Strings.toHexString(uint256(feedId_), 32);
+        } else {
+            sourceBase = sourceBase_;
+        }
+
+        if (sourceOracleType_ == PYTH_ORACLE_TYPE && bytes(sourceQuote_).length == 0) {
+            sourceQuote = "USD";
+        } else {
+            sourceQuote = sourceQuote_;
+        }
+    }
+
+    function getPriceUnsafe(
+        bytes32 id
+    ) external view override returns (PythStructs.Price memory price) {
+        return _latestPrice(id);
+    }
+
+    function getPriceNoOlderThan(
+        bytes32 id,
+        uint age
+    ) external view override returns (PythStructs.Price memory price) {
+        price = _latestPrice(id);
+        if (block.timestamp > price.publishTime + age) revert PythErrors.StalePrice();
+    }
+
+    function getEmaPriceUnsafe(
+        bytes32
+    ) external pure override returns (PythStructs.Price memory) {
+        revert UnsupportedPythMethod();
+    }
+
+    function getEmaPriceNoOlderThan(
+        bytes32,
+        uint
+    ) external pure override returns (PythStructs.Price memory) {
+        revert UnsupportedPythMethod();
+    }
+
+    function updatePriceFeeds(bytes[] calldata) external payable override {
+        _refundValue();
+    }
+
+    function updatePriceFeedsIfNecessary(
+        bytes[] calldata,
+        bytes32[] calldata,
+        uint64[] calldata
+    ) external payable override {
+        _refundValue();
+    }
+
+    function getUpdateFee(
+        bytes[] calldata
+    ) external pure override returns (uint feeAmount) {
+        return 0;
+    }
+
+    function getTwapUpdateFee(
+        bytes[] calldata
+    ) external pure override returns (uint feeAmount) {
+        return 0;
+    }
+
+    function parsePriceFeedUpdates(
+        bytes[] calldata,
+        bytes32[] calldata,
+        uint64,
+        uint64
+    ) external payable override returns (PythStructs.PriceFeed[] memory) {
+        revert UnsupportedPythMethod();
+    }
+
+    function parsePriceFeedUpdatesWithConfig(
+        bytes[] calldata,
+        bytes32[] calldata,
+        uint64,
+        uint64,
+        bool,
+        bool,
+        bool
+    ) external payable override returns (PythStructs.PriceFeed[] memory, uint64[] memory) {
+        revert UnsupportedPythMethod();
+    }
+
+    function parseTwapPriceFeedUpdates(
+        bytes[] calldata,
+        bytes32[] calldata
+    ) external payable override returns (PythStructs.TwapPriceFeed[] memory) {
+        revert UnsupportedPythMethod();
+    }
+
+    function parsePriceFeedUpdatesUnique(
+        bytes[] calldata,
+        bytes32[] calldata,
+        uint64,
+        uint64
+    ) external payable override returns (PythStructs.PriceFeed[] memory) {
+        revert UnsupportedPythMethod();
+    }
+
+    function _latestPrice(bytes32 id) internal view returns (PythStructs.Price memory price) {
+        if (id != FEED_ID) revert PythErrors.PriceFeedNotFound();
+
+        IOracleModule.PricePairState memory state =
+            ORACLE.oraclePricePairState(SOURCE_ORACLE_TYPE, sourceBase, sourceQuote);
+
+        uint256 scaledPrice = Math.mulDiv(
+            state.pairPrice,
+            10 ** uint256(FEED_DECIMALS),
+            PRECOMPILE_PRICE_SCALE
+        );
+        if (scaledPrice > uint256(uint64(type(int64).max))) revert PythErrors.CombinedPriceOverflow();
+
+        uint256 publishTime = state.baseTimestamp < state.quoteTimestamp ? state.baseTimestamp : state.quoteTimestamp;
+
+        price = PythStructs.Price({
+            // forge-lint: disable-next-line(unsafe-typecast)
+            price: int64(uint64(scaledPrice)),
+            conf: 0,
+            expo: -int32(uint32(FEED_DECIMALS)),
+            publishTime: publishTime
+        });
+    }
+
+    function _refundValue() internal {
+        if (msg.value == 0) return;
+
+        (bool success, ) = payable(msg.sender).call{value: msg.value}("");
+        require(success, "refund failed");
+    }
+}

--- a/src/InjectivePyth.sol
+++ b/src/InjectivePyth.sol
@@ -16,11 +16,12 @@ import {PythStructs} from "pyth-crosschain/target_chains/ethereum/sdk/solidity/P
 /// official `PythAggregatorV3` contract, which expects an `IPyth` contract plus
 /// a `priceId`.
 contract InjectivePyth is IPyth {
-    IOracleModule internal constant ORACLE =
-        IOracleModule(0x0000000000000000000000000000000000000067);
+    IOracleModule internal constant ORACLE = IOracleModule(0x0000000000000000000000000000000000000067);
 
+    uint256 internal constant MAX_INT64 = uint256(uint64(type(int64).max));
     uint8 internal constant PYTH_ORACLE_TYPE = 9;
     uint256 internal constant PRECOMPILE_PRICE_SCALE = 1e18;
+    string internal constant PYTH_USD_QUOTE = "USD";
 
     bytes32 public immutable FEED_ID;
     uint8 public immutable FEED_DECIMALS;
@@ -28,7 +29,7 @@ contract InjectivePyth is IPyth {
     string public sourceBase;
     string public sourceQuote;
 
-    error UnsupportedPythMethod();
+    error RefundFailed();
 
     constructor(
         bytes32 feedId_,
@@ -48,98 +49,98 @@ contract InjectivePyth is IPyth {
         }
 
         if (sourceOracleType_ == PYTH_ORACLE_TYPE && bytes(sourceQuote_).length == 0) {
-            sourceQuote = "USD";
+            sourceQuote = PYTH_USD_QUOTE;
         } else {
             sourceQuote = sourceQuote_;
         }
     }
 
-    function getPriceUnsafe(
-        bytes32 id
-    ) external view override returns (PythStructs.Price memory price) {
+    function getPriceUnsafe(bytes32 id) external view override returns (PythStructs.Price memory price) {
         return _latestPrice(id);
     }
 
-    function getPriceNoOlderThan(
-        bytes32 id,
-        uint age
-    ) external view override returns (PythStructs.Price memory price) {
+    function getPriceNoOlderThan(bytes32 id, uint256 age)
+        external
+        view
+        override
+        returns (PythStructs.Price memory price)
+    {
         price = _latestPrice(id);
-        if (block.timestamp > price.publishTime + age) revert PythErrors.StalePrice();
+        _revertIfStale(price.publishTime, age);
     }
 
-    function getEmaPriceUnsafe(
-        bytes32
-    ) external pure override returns (PythStructs.Price memory) {
-        revert UnsupportedPythMethod();
+    function getEmaPriceUnsafe(bytes32 id) external view override returns (PythStructs.Price memory price) {
+        return _latestPrice(id);
     }
 
-    function getEmaPriceNoOlderThan(
-        bytes32,
-        uint
-    ) external pure override returns (PythStructs.Price memory) {
-        revert UnsupportedPythMethod();
+    function getEmaPriceNoOlderThan(bytes32 id, uint256 age)
+        external
+        view
+        override
+        returns (PythStructs.Price memory price)
+    {
+        price = _latestPrice(id);
+        _revertIfStale(price.publishTime, age);
     }
 
     function updatePriceFeeds(bytes[] calldata) external payable override {
         _refundValue();
     }
 
-    function updatePriceFeedsIfNecessary(
-        bytes[] calldata,
-        bytes32[] calldata,
-        uint64[] calldata
-    ) external payable override {
+    function updatePriceFeedsIfNecessary(bytes[] calldata, bytes32[] calldata, uint64[] calldata)
+        external
+        payable
+        override
+    {
         _refundValue();
     }
 
-    function getUpdateFee(
-        bytes[] calldata
-    ) external pure override returns (uint feeAmount) {
+    function getUpdateFee(bytes[] calldata) external pure override returns (uint256 feeAmount) {
         return 0;
     }
 
-    function getTwapUpdateFee(
-        bytes[] calldata
-    ) external pure override returns (uint feeAmount) {
+    function getTwapUpdateFee(bytes[] calldata) external pure override returns (uint256 feeAmount) {
         return 0;
     }
 
-    function parsePriceFeedUpdates(
-        bytes[] calldata,
-        bytes32[] calldata,
-        uint64,
-        uint64
-    ) external payable override returns (PythStructs.PriceFeed[] memory) {
-        revert UnsupportedPythMethod();
+    function parsePriceFeedUpdates(bytes[] calldata, bytes32[] calldata, uint64, uint64)
+        external
+        payable
+        override
+        returns (PythStructs.PriceFeed[] memory priceFeeds)
+    {
+        _refundValue();
+        return new PythStructs.PriceFeed[](0);
     }
 
-    function parsePriceFeedUpdatesWithConfig(
-        bytes[] calldata,
-        bytes32[] calldata,
-        uint64,
-        uint64,
-        bool,
-        bool,
-        bool
-    ) external payable override returns (PythStructs.PriceFeed[] memory, uint64[] memory) {
-        revert UnsupportedPythMethod();
+    function parsePriceFeedUpdatesWithConfig(bytes[] calldata, bytes32[] calldata, uint64, uint64, bool, bool, bool)
+        external
+        payable
+        override
+        returns (PythStructs.PriceFeed[] memory priceFeeds, uint64[] memory slots)
+    {
+        _refundValue();
+        return (new PythStructs.PriceFeed[](0), new uint64[](0));
     }
 
-    function parseTwapPriceFeedUpdates(
-        bytes[] calldata,
-        bytes32[] calldata
-    ) external payable override returns (PythStructs.TwapPriceFeed[] memory) {
-        revert UnsupportedPythMethod();
+    function parseTwapPriceFeedUpdates(bytes[] calldata, bytes32[] calldata)
+        external
+        payable
+        override
+        returns (PythStructs.TwapPriceFeed[] memory twapPriceFeeds)
+    {
+        _refundValue();
+        return new PythStructs.TwapPriceFeed[](0);
     }
 
-    function parsePriceFeedUpdatesUnique(
-        bytes[] calldata,
-        bytes32[] calldata,
-        uint64,
-        uint64
-    ) external payable override returns (PythStructs.PriceFeed[] memory) {
-        revert UnsupportedPythMethod();
+    function parsePriceFeedUpdatesUnique(bytes[] calldata, bytes32[] calldata, uint64, uint64)
+        external
+        payable
+        override
+        returns (PythStructs.PriceFeed[] memory priceFeeds)
+    {
+        _refundValue();
+        return new PythStructs.PriceFeed[](0);
     }
 
     function _latestPrice(bytes32 id) internal view returns (PythStructs.Price memory price) {
@@ -148,28 +149,31 @@ contract InjectivePyth is IPyth {
         IOracleModule.PricePairState memory state =
             ORACLE.oraclePricePairState(SOURCE_ORACLE_TYPE, sourceBase, sourceQuote);
 
-        uint256 scaledPrice = Math.mulDiv(
-            state.pairPrice,
-            10 ** uint256(FEED_DECIMALS),
-            PRECOMPILE_PRICE_SCALE
-        );
-        if (scaledPrice > uint256(uint64(type(int64).max))) revert PythErrors.CombinedPriceOverflow();
-
-        uint256 publishTime = state.baseTimestamp < state.quoteTimestamp ? state.baseTimestamp : state.quoteTimestamp;
+        uint256 scaledPrice = Math.mulDiv(state.pairPrice, 10 ** uint256(FEED_DECIMALS), PRECOMPILE_PRICE_SCALE);
+        if (scaledPrice > MAX_INT64) revert PythErrors.CombinedPriceOverflow();
 
         price = PythStructs.Price({
             // forge-lint: disable-next-line(unsafe-typecast)
             price: int64(uint64(scaledPrice)),
             conf: 0,
             expo: -int32(uint32(FEED_DECIMALS)),
-            publishTime: publishTime
+            publishTime: _updatedAt(state)
         });
+    }
+
+    function _revertIfStale(uint256 publishTime, uint256 age) internal view {
+        if (publishTime > block.timestamp) revert PythErrors.StalePrice();
+        if (block.timestamp - publishTime > age) revert PythErrors.StalePrice();
+    }
+
+    function _updatedAt(IOracleModule.PricePairState memory state) internal pure returns (uint256) {
+        return state.baseTimestamp < state.quoteTimestamp ? state.baseTimestamp : state.quoteTimestamp;
     }
 
     function _refundValue() internal {
         if (msg.value == 0) return;
 
-        (bool success, ) = payable(msg.sender).call{value: msg.value}("");
-        require(success, "refund failed");
+        (bool success,) = payable(msg.sender).call{value: msg.value}("");
+        if (!success) revert RefundFailed();
     }
 }

--- a/src/InjectivePyth.sol
+++ b/src/InjectivePyth.sol
@@ -15,6 +15,10 @@ import {PythStructs} from "pyth-crosschain/target_chains/ethereum/sdk/solidity/P
 /// @dev This adapter is intentionally feed-specific. It exists to satisfy the
 /// official `PythAggregatorV3` contract, which expects an `IPyth` contract plus
 /// a `priceId`.
+///
+/// Injective already stores oracle prices natively on-chain, so this adapter
+/// does not implement the full stateful Pyth update/parsing workflow. The
+/// payable update and parse methods below are compatibility shims only.
 contract InjectivePyth is IPyth {
     IOracleModule internal constant ORACLE = IOracleModule(0x0000000000000000000000000000000000000067);
 
@@ -70,6 +74,9 @@ contract InjectivePyth is IPyth {
     }
 
     function getEmaPriceUnsafe(bytes32 id) external view override returns (PythStructs.Price memory price) {
+        // Partial implementation: the precompile does not expose EMA data in
+        // Pyth's format, so this adapter aliases EMA reads to the latest spot
+        // price instead of attempting to synthesize a separate series.
         return _latestPrice(id);
     }
 
@@ -84,6 +91,8 @@ contract InjectivePyth is IPyth {
     }
 
     function updatePriceFeeds(bytes[] calldata) external payable override {
+        // No-op compatibility method. Native Injective oracle data is already
+        // on-chain, so there is no signed update blob to submit here.
         _refundValue();
     }
 
@@ -92,14 +101,17 @@ contract InjectivePyth is IPyth {
         payable
         override
     {
+        // No-op for the same reason as `updatePriceFeeds`.
         _refundValue();
     }
 
     function getUpdateFee(bytes[] calldata) external pure override returns (uint256 feeAmount) {
+        // No external update payload is consumed, so there is no fee model.
         return 0;
     }
 
     function getTwapUpdateFee(bytes[] calldata) external pure override returns (uint256 feeAmount) {
+        // TWAP update blobs are not consumed either.
         return 0;
     }
 
@@ -109,6 +121,8 @@ contract InjectivePyth is IPyth {
         override
         returns (PythStructs.PriceFeed[] memory priceFeeds)
     {
+        // No-op compatibility method. This adapter does not parse Pyth update
+        // messages because the price source is the native oracle precompile.
         _refundValue();
         return new PythStructs.PriceFeed[](0);
     }
@@ -119,6 +133,7 @@ contract InjectivePyth is IPyth {
         override
         returns (PythStructs.PriceFeed[] memory priceFeeds, uint64[] memory slots)
     {
+        // Same as `parsePriceFeedUpdates`: keep the ABI, return no parsed data.
         _refundValue();
         return (new PythStructs.PriceFeed[](0), new uint64[](0));
     }
@@ -129,6 +144,7 @@ contract InjectivePyth is IPyth {
         override
         returns (PythStructs.TwapPriceFeed[] memory twapPriceFeeds)
     {
+        // Partial implementation: no TWAP feed translation is provided here.
         _refundValue();
         return new PythStructs.TwapPriceFeed[](0);
     }
@@ -139,6 +155,7 @@ contract InjectivePyth is IPyth {
         override
         returns (PythStructs.PriceFeed[] memory priceFeeds)
     {
+        // Same no-op behavior as the other parse methods.
         _refundValue();
         return new PythStructs.PriceFeed[](0);
     }

--- a/src/tests/InjectiveOracleWrappersTest.sol
+++ b/src/tests/InjectiveOracleWrappersTest.sol
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+
+import {IOracleModule} from "../Oracle.sol";
+import {InjectiveMorphoAggregatorV3} from "../InjectiveMorphoAggregatorV3.sol";
+import {InjectivePyth} from "../InjectivePyth.sol";
+import {PythAggregatorV3} from "pyth-crosschain/target_chains/ethereum/sdk/solidity/PythAggregatorV3.sol";
+import {PythStructs} from "pyth-crosschain/target_chains/ethereum/sdk/solidity/PythStructs.sol";
+import {MorphoChainlinkOracleV2} from "morpho-blue-oracles/src/morpho-chainlink/MorphoChainlinkOracleV2.sol";
+import {AggregatorV3Interface} from "morpho-blue-oracles/src/morpho-chainlink/interfaces/AggregatorV3Interface.sol";
+import {IERC4626} from "morpho-blue-oracles/src/morpho-chainlink/libraries/VaultLib.sol";
+
+contract MockOraclePrecompile is IOracleModule {
+    mapping(bytes32 => PricePairState) internal states;
+
+    function setPricePairState(
+        uint8 oracleType,
+        string calldata base,
+        string calldata quote,
+        PricePairState calldata state
+    ) external {
+        states[_key(oracleType, base, quote)] = state;
+    }
+
+    function oraclePrice(
+        uint8 oracleType,
+        string calldata base,
+        string calldata quote
+    ) external view returns (uint256 price) {
+        return states[_key(oracleType, base, quote)].pairPrice;
+    }
+
+    function oraclePricePairState(
+        uint8 oracleType,
+        string calldata base,
+        string calldata quote
+    ) external view returns (PricePairState memory state) {
+        return states[_key(oracleType, base, quote)];
+    }
+
+    function oraclePricePairStateScaled(
+        uint8 oracleType,
+        string calldata base,
+        string calldata quote,
+        uint32,
+        uint32
+    ) external view returns (PricePairState memory state) {
+        return states[_key(oracleType, base, quote)];
+    }
+
+    function _key(
+        uint8 oracleType,
+        string calldata base,
+        string calldata quote
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encode(oracleType, base, quote));
+    }
+}
+
+contract InjectiveOracleWrappersTest is Test {
+    address internal constant ORACLE_PRECOMPILE = 0x0000000000000000000000000000000000000067;
+
+    uint8 internal constant ORACLE_TYPE_PYTH = 9;
+    uint8 internal constant ORACLE_TYPE_CHAINLINK_DATA_STREAMS = 13;
+
+    bytes32 internal constant PYTH_BTC_USD_ID =
+        0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43;
+    bytes32 internal constant PYTH_USDC_USD_ID =
+        0xeaa020c61cc479712813461ce153894a96a6c00b21ed0cfcfdb74db759d5e0b3;
+    bytes32 internal constant SYNTHETIC_CHAINLINK_BTC_USD_ID =
+        keccak256("injective:chainlink:btc-usd");
+
+    MockOraclePrecompile internal oraclePrecompile;
+
+    function setUp() public {
+        MockOraclePrecompile mock = new MockOraclePrecompile();
+        vm.etch(ORACLE_PRECOMPILE, address(mock).code);
+        oraclePrecompile = MockOraclePrecompile(ORACLE_PRECOMPILE);
+    }
+
+    function test_OfficialPythAggregatorV3_WorksWithNativePythSource() public {
+        oraclePrecompile.setPricePairState(
+            ORACLE_TYPE_PYTH,
+            "0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
+            "USD",
+            IOracleModule.PricePairState({
+                pairPrice: 42_000e18,
+                basePrice: 42_000e18,
+                quotePrice: 0,
+                baseCumulativePrice: 0,
+                quoteCumulativePrice: 0,
+                baseTimestamp: 1_717_171_717,
+                quoteTimestamp: 1_717_171_717
+            })
+        );
+
+        InjectivePyth injectivePyth = new InjectivePyth(
+            PYTH_BTC_USD_ID,
+            ORACLE_TYPE_PYTH,
+            "",
+            "",
+            8
+        );
+        PythAggregatorV3 aggregator = new PythAggregatorV3(address(injectivePyth), PYTH_BTC_USD_ID);
+
+        PythStructs.Price memory rawPrice = injectivePyth.getPriceUnsafe(PYTH_BTC_USD_ID);
+
+        assertEq(rawPrice.price, 4_200_000_000_000);
+        assertEq(rawPrice.expo, -8);
+        assertEq(rawPrice.publishTime, 1_717_171_717);
+        assertEq(aggregator.decimals(), 8);
+        assertEq(aggregator.latestAnswer(), 4_200_000_000_000);
+        assertEq(aggregator.latestTimestamp(), 1_717_171_717);
+    }
+
+    function test_OfficialPythAggregatorV3_WorksWithChainlinkNativeSource() public {
+        oraclePrecompile.setPricePairState(
+            ORACLE_TYPE_CHAINLINK_DATA_STREAMS,
+            "BTC",
+            "USD",
+            IOracleModule.PricePairState({
+                pairPrice: 42_500e18,
+                basePrice: 42_500e18,
+                quotePrice: 0,
+                baseCumulativePrice: 0,
+                quoteCumulativePrice: 0,
+                baseTimestamp: 1_818,
+                quoteTimestamp: 1_818
+            })
+        );
+
+        InjectivePyth injectivePyth = new InjectivePyth(
+            SYNTHETIC_CHAINLINK_BTC_USD_ID,
+            ORACLE_TYPE_CHAINLINK_DATA_STREAMS,
+            "BTC",
+            "USD",
+            8
+        );
+        PythAggregatorV3 aggregator =
+            new PythAggregatorV3(address(injectivePyth), SYNTHETIC_CHAINLINK_BTC_USD_ID);
+
+        assertEq(aggregator.decimals(), 8);
+        assertEq(aggregator.latestAnswer(), 4_250_000_000_000);
+        assertEq(aggregator.latestRound(), 1_818);
+    }
+
+    function test_MorphoWrapper_ExposesNativePythAsAggregatorV3() public {
+        oraclePrecompile.setPricePairState(
+            ORACLE_TYPE_PYTH,
+            "0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
+            "USD",
+            IOracleModule.PricePairState({
+                pairPrice: 42_000e18,
+                basePrice: 42_000e18,
+                quotePrice: 0,
+                baseCumulativePrice: 0,
+                quoteCumulativePrice: 0,
+                baseTimestamp: 1_234_567_890,
+                quoteTimestamp: 1_234_567_890
+            })
+        );
+
+        InjectiveMorphoAggregatorV3 feed = new InjectiveMorphoAggregatorV3(
+            ORACLE_TYPE_PYTH,
+            "0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
+            "USD",
+            8,
+            "Injective Pyth BTC / USD"
+        );
+
+        (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        ) = feed.latestRoundData();
+
+        assertEq(feed.decimals(), 8);
+        assertEq(answer, 4_200_000_000_000);
+        assertEq(roundId, 1_234_567_890);
+        assertEq(startedAt, 1_234_567_890);
+        assertEq(updatedAt, 1_234_567_890);
+        assertEq(answeredInRound, 1_234_567_890);
+    }
+
+    function test_OfficialMorphoChainlinkOracleV2_DeploysWithPythBackedWrapper() public {
+        oraclePrecompile.setPricePairState(
+            ORACLE_TYPE_PYTH,
+            "0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
+            "USD",
+            IOracleModule.PricePairState({
+                pairPrice: 42_000e18,
+                basePrice: 42_000e18,
+                quotePrice: 0,
+                baseCumulativePrice: 0,
+                quoteCumulativePrice: 0,
+                baseTimestamp: 100,
+                quoteTimestamp: 100
+            })
+        );
+
+        oraclePrecompile.setPricePairState(
+            ORACLE_TYPE_PYTH,
+            "0xeaa020c61cc479712813461ce153894a96a6c00b21ed0cfcfdb74db759d5e0b3",
+            "USD",
+            IOracleModule.PricePairState({
+                pairPrice: 1e18,
+                basePrice: 1e18,
+                quotePrice: 0,
+                baseCumulativePrice: 0,
+                quoteCumulativePrice: 0,
+                baseTimestamp: 100,
+                quoteTimestamp: 100
+            })
+        );
+
+        InjectiveMorphoAggregatorV3 btcUsd = new InjectiveMorphoAggregatorV3(
+            ORACLE_TYPE_PYTH,
+            "0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
+            "USD",
+            8,
+            "Injective Pyth BTC / USD"
+        );
+        InjectiveMorphoAggregatorV3 usdcUsd = new InjectiveMorphoAggregatorV3(
+            ORACLE_TYPE_PYTH,
+            "0xeaa020c61cc479712813461ce153894a96a6c00b21ed0cfcfdb74db759d5e0b3",
+            "USD",
+            8,
+            "Injective Pyth USDC / USD"
+        );
+
+        MorphoChainlinkOracleV2 morphoOracle = new MorphoChainlinkOracleV2(
+            IERC4626(address(0)),
+            1,
+            AggregatorV3Interface(address(btcUsd)),
+            AggregatorV3Interface(address(0)),
+            8,
+            IERC4626(address(0)),
+            1,
+            AggregatorV3Interface(address(usdcUsd)),
+            AggregatorV3Interface(address(0)),
+            6
+        );
+
+        uint256 expectedScaleFactor = 10 ** 34;
+        uint256 expectedPrice = expectedScaleFactor * 4_200_000_000_000 / 100_000_000;
+
+        assertEq(morphoOracle.SCALE_FACTOR(), expectedScaleFactor);
+        assertEq(morphoOracle.price(), expectedPrice);
+    }
+}

--- a/src/tests/InjectiveOracleWrappersTest.sol
+++ b/src/tests/InjectiveOracleWrappersTest.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 import "forge-std/Test.sol";
 
 import {IOracleModule} from "../Oracle.sol";
-import {InjectiveMorphoAggregatorV3} from "../InjectiveMorphoAggregatorV3.sol";
+import {InjectiveAggregatorV3} from "../InjectiveAggregatorV3.sol";
 import {InjectivePyth} from "../InjectivePyth.sol";
 import {PythAggregatorV3} from "pyth-crosschain/target_chains/ethereum/sdk/solidity/PythAggregatorV3.sol";
 import {PythStructs} from "pyth-crosschain/target_chains/ethereum/sdk/solidity/PythStructs.sol";
@@ -205,7 +205,7 @@ contract InjectiveOracleWrappersTest is Test {
             })
         );
 
-        InjectiveMorphoAggregatorV3 feed = new InjectiveMorphoAggregatorV3(
+        InjectiveAggregatorV3 feed = new InjectiveAggregatorV3(
             ORACLE_TYPE_PYTH,
             "0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
             "USD",
@@ -255,14 +255,14 @@ contract InjectiveOracleWrappersTest is Test {
             })
         );
 
-        InjectiveMorphoAggregatorV3 btcUsd = new InjectiveMorphoAggregatorV3(
+        InjectiveAggregatorV3 btcUsd = new InjectiveAggregatorV3(
             ORACLE_TYPE_PYTH,
             "0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
             "USD",
             8,
             "Injective Pyth BTC / USD"
         );
-        InjectiveMorphoAggregatorV3 usdcUsd = new InjectiveMorphoAggregatorV3(
+        InjectiveAggregatorV3 usdcUsd = new InjectiveAggregatorV3(
             ORACLE_TYPE_PYTH,
             "0xeaa020c61cc479712813461ce153894a96a6c00b21ed0cfcfdb74db759d5e0b3",
             "USD",

--- a/src/tests/InjectiveOracleWrappersTest.sol
+++ b/src/tests/InjectiveOracleWrappersTest.sol
@@ -24,37 +24,31 @@ contract MockOraclePrecompile is IOracleModule {
         states[_key(oracleType, base, quote)] = state;
     }
 
-    function oraclePrice(
-        uint8 oracleType,
-        string calldata base,
-        string calldata quote
-    ) external view returns (uint256 price) {
+    function oraclePrice(uint8 oracleType, string calldata base, string calldata quote)
+        external
+        view
+        returns (uint256 price)
+    {
         return states[_key(oracleType, base, quote)].pairPrice;
     }
 
-    function oraclePricePairState(
-        uint8 oracleType,
-        string calldata base,
-        string calldata quote
-    ) external view returns (PricePairState memory state) {
+    function oraclePricePairState(uint8 oracleType, string calldata base, string calldata quote)
+        external
+        view
+        returns (PricePairState memory state)
+    {
         return states[_key(oracleType, base, quote)];
     }
 
-    function oraclePricePairStateScaled(
-        uint8 oracleType,
-        string calldata base,
-        string calldata quote,
-        uint32,
-        uint32
-    ) external view returns (PricePairState memory state) {
+    function oraclePricePairStateScaled(uint8 oracleType, string calldata base, string calldata quote, uint32, uint32)
+        external
+        view
+        returns (PricePairState memory state)
+    {
         return states[_key(oracleType, base, quote)];
     }
 
-    function _key(
-        uint8 oracleType,
-        string calldata base,
-        string calldata quote
-    ) internal pure returns (bytes32) {
+    function _key(uint8 oracleType, string calldata base, string calldata quote) internal pure returns (bytes32) {
         return keccak256(abi.encode(oracleType, base, quote));
     }
 }
@@ -65,14 +59,13 @@ contract InjectiveOracleWrappersTest is Test {
     uint8 internal constant ORACLE_TYPE_PYTH = 9;
     uint8 internal constant ORACLE_TYPE_CHAINLINK_DATA_STREAMS = 13;
 
-    bytes32 internal constant PYTH_BTC_USD_ID =
-        0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43;
-    bytes32 internal constant PYTH_USDC_USD_ID =
-        0xeaa020c61cc479712813461ce153894a96a6c00b21ed0cfcfdb74db759d5e0b3;
-    bytes32 internal constant SYNTHETIC_CHAINLINK_BTC_USD_ID =
-        keccak256("injective:chainlink:btc-usd");
+    bytes32 internal constant PYTH_BTC_USD_ID = 0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43;
+    bytes32 internal constant PYTH_USDC_USD_ID = 0xeaa020c61cc479712813461ce153894a96a6c00b21ed0cfcfdb74db759d5e0b3;
+    bytes32 internal constant SYNTHETIC_CHAINLINK_BTC_USD_ID = keccak256("injective:chainlink:btc-usd");
 
     MockOraclePrecompile internal oraclePrecompile;
+
+    receive() external payable {}
 
     function setUp() public {
         MockOraclePrecompile mock = new MockOraclePrecompile();
@@ -96,13 +89,7 @@ contract InjectiveOracleWrappersTest is Test {
             })
         );
 
-        InjectivePyth injectivePyth = new InjectivePyth(
-            PYTH_BTC_USD_ID,
-            ORACLE_TYPE_PYTH,
-            "",
-            "",
-            8
-        );
+        InjectivePyth injectivePyth = new InjectivePyth(PYTH_BTC_USD_ID, ORACLE_TYPE_PYTH, "", "", 8);
         PythAggregatorV3 aggregator = new PythAggregatorV3(address(injectivePyth), PYTH_BTC_USD_ID);
 
         PythStructs.Price memory rawPrice = injectivePyth.getPriceUnsafe(PYTH_BTC_USD_ID);
@@ -113,6 +100,68 @@ contract InjectiveOracleWrappersTest is Test {
         assertEq(aggregator.decimals(), 8);
         assertEq(aggregator.latestAnswer(), 4_200_000_000_000);
         assertEq(aggregator.latestTimestamp(), 1_717_171_717);
+    }
+
+    function test_InjectivePyth_ExtraSurfaceIsNoOp() public {
+        oraclePrecompile.setPricePairState(
+            ORACLE_TYPE_PYTH,
+            "0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
+            "USD",
+            IOracleModule.PricePairState({
+                pairPrice: 42_000e18,
+                basePrice: 42_000e18,
+                quotePrice: 0,
+                baseCumulativePrice: 0,
+                quoteCumulativePrice: 0,
+                baseTimestamp: 1_717_171_717,
+                quoteTimestamp: 1_717_171_717
+            })
+        );
+
+        InjectivePyth injectivePyth = new InjectivePyth(PYTH_BTC_USD_ID, ORACLE_TYPE_PYTH, "", "", 8);
+
+        vm.warp(1_717_171_717);
+
+        PythStructs.Price memory spotPrice = injectivePyth.getPriceUnsafe(PYTH_BTC_USD_ID);
+        PythStructs.Price memory emaPrice = injectivePyth.getEmaPriceUnsafe(PYTH_BTC_USD_ID);
+        PythStructs.Price memory recentEmaPrice =
+            injectivePyth.getEmaPriceNoOlderThan(PYTH_BTC_USD_ID, type(uint256).max);
+
+        assertEq(emaPrice.price, spotPrice.price);
+        assertEq(emaPrice.conf, spotPrice.conf);
+        assertEq(emaPrice.expo, spotPrice.expo);
+        assertEq(emaPrice.publishTime, spotPrice.publishTime);
+        assertEq(recentEmaPrice.price, spotPrice.price);
+        assertEq(recentEmaPrice.publishTime, spotPrice.publishTime);
+
+        vm.deal(address(this), 1 ether);
+        uint256 balanceBefore = address(this).balance;
+        bytes[] memory updateData = new bytes[](0);
+        bytes32[] memory priceIds = new bytes32[](0);
+        uint64[] memory publishTimes = new uint64[](0);
+
+        injectivePyth.updatePriceFeeds{value: 0.25 ether}(updateData);
+        assertEq(address(this).balance, balanceBefore);
+
+        injectivePyth.updatePriceFeedsIfNecessary{value: 0.25 ether}(updateData, priceIds, publishTimes);
+        assertEq(address(this).balance, balanceBefore);
+
+        PythStructs.PriceFeed[] memory parsedFeeds =
+            injectivePyth.parsePriceFeedUpdates(updateData, priceIds, 0, type(uint64).max);
+        assertEq(parsedFeeds.length, 0);
+
+        (PythStructs.PriceFeed[] memory configFeeds, uint64[] memory slots) = injectivePyth.parsePriceFeedUpdatesWithConfig(
+            updateData, priceIds, 0, type(uint64).max, false, false, false
+        );
+        assertEq(configFeeds.length, 0);
+        assertEq(slots.length, 0);
+
+        PythStructs.TwapPriceFeed[] memory twapFeeds = injectivePyth.parseTwapPriceFeedUpdates(updateData, priceIds);
+        assertEq(twapFeeds.length, 0);
+
+        PythStructs.PriceFeed[] memory uniqueFeeds =
+            injectivePyth.parsePriceFeedUpdatesUnique(updateData, priceIds, 0, type(uint64).max);
+        assertEq(uniqueFeeds.length, 0);
     }
 
     function test_OfficialPythAggregatorV3_WorksWithChainlinkNativeSource() public {
@@ -131,15 +180,9 @@ contract InjectiveOracleWrappersTest is Test {
             })
         );
 
-        InjectivePyth injectivePyth = new InjectivePyth(
-            SYNTHETIC_CHAINLINK_BTC_USD_ID,
-            ORACLE_TYPE_CHAINLINK_DATA_STREAMS,
-            "BTC",
-            "USD",
-            8
-        );
-        PythAggregatorV3 aggregator =
-            new PythAggregatorV3(address(injectivePyth), SYNTHETIC_CHAINLINK_BTC_USD_ID);
+        InjectivePyth injectivePyth =
+            new InjectivePyth(SYNTHETIC_CHAINLINK_BTC_USD_ID, ORACLE_TYPE_CHAINLINK_DATA_STREAMS, "BTC", "USD", 8);
+        PythAggregatorV3 aggregator = new PythAggregatorV3(address(injectivePyth), SYNTHETIC_CHAINLINK_BTC_USD_ID);
 
         assertEq(aggregator.decimals(), 8);
         assertEq(aggregator.latestAnswer(), 4_250_000_000_000);
@@ -170,13 +213,8 @@ contract InjectiveOracleWrappersTest is Test {
             "Injective Pyth BTC / USD"
         );
 
-        (
-            uint80 roundId,
-            int256 answer,
-            uint256 startedAt,
-            uint256 updatedAt,
-            uint80 answeredInRound
-        ) = feed.latestRoundData();
+        (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) =
+            feed.latestRoundData();
 
         assertEq(feed.decimals(), 8);
         assertEq(answer, 4_200_000_000_000);


### PR DESCRIPTION
Intermediary contracts between Injective's Oracle precompile and the expected interfaces to obtain a price:
- `PythAggregatorV3` 
- `AggregatorV3Interface`

Solves [IC-1040](https://linear.app/injectivelabs/issue/IC-1040/morpho-compatible-adapter-for-oracle-precompile)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added oracle wrappers that enable Injective oracle data access through Chainlink and Pyth-compatible interfaces.
  * Oracle wrappers support standard price feeds with configurable decimals and descriptions.

* **Chores**
  * Added new project dependencies for oracle infrastructure libraries.
  * Updated configuration to support new dependency integrations.

* **Tests**
  * Added comprehensive test suite validating oracle wrapper behavior and compatibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InjectiveLabs/solidity-contracts/pull/29)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->