### PR TITLE
[ic-1076][ibc] add precompile for ICS20 transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For more details, see the [Staking Precompile documentation](docs/staking_precom
 
 ### IBC Transfer Precompile
 
-The IBC Transfer Precompile allows EVM accounts and contracts to initiate synchronous ICS-20 transfers using mapped Multi-VM Token Standard assets. The caller becomes the authenticated IBC sender, and the packet sequence is returned to the calling contract.
+The IBC Transfer Precompile at `0x0000000000000000000000000000000000000069` allows EVM accounts and contracts to initiate synchronous ICS-20 transfers using mapped Multi-VM Token Standard assets. The caller becomes the authenticated IBC sender, and the packet sequence is returned to the calling contract.
 
 For the proposed interface and transfer semantics, see the [IBC Transfer Precompile documentation](docs/ibc_precompile.md).
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ The Staking Precompile provides a system smart contract interface for interactin
 
 For more details, see the [Staking Precompile documentation](docs/staking_precompile.md) and try out the [Staking demo](demos/staking/README.md).
 
+### IBC Transfer Precompile
+
+The IBC Transfer Precompile allows EVM accounts and contracts to initiate synchronous ICS-20 transfers using mapped Multi-VM Token Standard assets. The caller becomes the authenticated IBC sender, and the packet sequence is returned to the calling contract.
+
+For the proposed interface and transfer semantics, see the [IBC Transfer Precompile documentation](docs/ibc_precompile.md).
+
 ## Pre-signed Transactions
 
 ### WINJ9

--- a/docs/ibc_precompile.md
+++ b/docs/ibc_precompile.md
@@ -1,0 +1,92 @@
+# IBC Transfer Precompile
+
+## Overview
+
+The IBC transfer precompile lets an EVM account or contract initiate an
+ICS-20 transfer. Its Solidity interface is `IIBCModule`, defined in
+[`src/IBC.sol`](../src/IBC.sol).
+
+The precompile address is intentionally not documented yet. It must be
+allocated when the implementation is registered in `injective-core`.
+
+## Interface
+
+```solidity
+interface IIBCModule {
+    struct TimeoutHeight {
+        uint64 revisionNumber;
+        uint64 revisionHeight;
+    }
+
+    function transfer(
+        string calldata sourceChannel,
+        string calldata receiver,
+        address token,
+        uint256 amount,
+        TimeoutHeight calldata timeoutHeight,
+        uint64 timeoutTimestamp,
+        string calldata memo
+    ) external returns (uint64 sequence);
+}
+```
+
+The canonical ABI signature is:
+
+```text
+transfer(string,string,address,uint256,(uint64,uint64),uint64,string)
+```
+
+## Transfer semantics
+
+- The source port is implicitly `transfer`.
+- The IBC sender is the Injective Bech32 address derived from `msg.sender`.
+  Callers cannot provide a different sender.
+- `receiver` is the address understood by the counterparty chain. Its format is
+  not restricted to an Injective or EVM address.
+- `token` must resolve to a supported MTS bank denomination. An unknown token
+  causes the call to revert.
+- `amount` uses the token's smallest denomination and must be positive.
+- No ERC-20 `approve` call is required. The precompile acts on the caller's
+  native bank-backed MTS balance.
+- Escrow or burn, packet creation, and packet commitment happen synchronously.
+  The caller's balance reflects the transfer when the call returns.
+- If the EVM execution containing the call later reverts, the balance change,
+  packet commitment, sequence update, and associated events must also be
+  reverted.
+- If the packet later fails or times out, normal ICS-20 acknowledgement and
+  timeout handling returns the funds to the sender.
+- A successful call returns the outbound packet sequence number.
+
+## Timeouts
+
+`timeoutHeight` is evaluated using the counterparty chain's IBC client height:
+
+- `revisionNumber` identifies the counterparty chain revision.
+- `revisionHeight` is the block height within that revision.
+- `{ revisionNumber: 0, revisionHeight: 0 }` disables the height timeout.
+
+`timeoutTimestamp` is an absolute Unix timestamp in nanoseconds. A value of
+zero disables the timestamp timeout. Callers should query current counterparty
+chain state and add an appropriate safety margin. The underlying IBC
+implementation validates the resulting timeout configuration.
+
+## Receiver and memo limits
+
+The precompile should apply the limits enforced by the underlying ibc-go
+version. At the time this interface was specified, those limits are:
+
+- Receiver: 2,048 bytes.
+- Memo: 32,768 bytes.
+
+No smaller precompile-specific limits should be imposed.
+
+## Failure behavior
+
+The call reverts without partial native or EVM state changes when, for example:
+
+- The token cannot be resolved to an MTS denomination.
+- The channel or timeout is invalid.
+- The receiver or memo fails ICS-20 validation.
+- The amount is zero or exceeds the caller's spendable balance.
+- IBC sending is disabled for the token or channel.
+- Packet creation, escrow, burn, or commitment fails.

--- a/docs/ibc_precompile.md
+++ b/docs/ibc_precompile.md
@@ -6,8 +6,10 @@ The IBC transfer precompile lets an EVM account or contract initiate an
 ICS-20 transfer. Its Solidity interface is `IIBCModule`, defined in
 [`src/IBC.sol`](../src/IBC.sol).
 
-The precompile address is intentionally not documented yet. It must be
-allocated when the implementation is registered in `injective-core`.
+| Property | Value |
+|----------|-------|
+| Address | `0x0000000000000000000000000000000000000069` |
+| Interface | `IIBCModule` |
 
 ## Interface
 

--- a/src/IBC.sol
+++ b/src/IBC.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.20;
 
 /// @title Injective IBC transfer precompile
 /// @notice Initiates ICS-20 transfers from EVM accounts and contracts.
+/// @dev Deployed at 0x0000000000000000000000000000000000000069.
 interface IIBCModule {
     /// @notice Identifies an IBC client revision and a block height within it.
     /// @dev Set both fields to zero to disable the height-based timeout.

--- a/src/IBC.sol
+++ b/src/IBC.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title Injective IBC transfer precompile
+/// @notice Initiates ICS-20 transfers from EVM accounts and contracts.
+interface IIBCModule {
+    /// @notice Identifies an IBC client revision and a block height within it.
+    /// @dev Set both fields to zero to disable the height-based timeout.
+    struct TimeoutHeight {
+        uint64 revisionNumber;
+        uint64 revisionHeight;
+    }
+
+    /// @notice Transfers an MTS token over an ICS-20 channel.
+    /// @dev The source port is implicitly `transfer`. The IBC sender is the
+    ///      Injective Bech32 address derived from `msg.sender`.
+    ///
+    ///      The token must resolve to a supported MTS bank denomination. The
+    ///      amount is debited synchronously and is escrowed or burned according
+    ///      to ICS-20 semantics. No ERC-20 approval is required.
+    ///
+    ///      A zero timeout height disables the height-based timeout. A zero
+    ///      timeout timestamp disables the timestamp-based timeout. The call
+    ///      must supply a timeout accepted by the underlying IBC implementation.
+    ///
+    /// @param sourceChannel Source-side ICS-20 channel identifier.
+    /// @param receiver Receiver address on the counterparty chain.
+    /// @param token EVM address of the MTS token to transfer.
+    /// @param amount Amount in the token's smallest denomination.
+    /// @param timeoutHeight Counterparty-chain IBC timeout height.
+    /// @param timeoutTimestamp Absolute Unix timeout timestamp in nanoseconds.
+    /// @param memo ICS-20 packet memo.
+    /// @return sequence Sequence number assigned to the outbound IBC packet.
+    function transfer(
+        string calldata sourceChannel,
+        string calldata receiver,
+        address token,
+        uint256 amount,
+        TimeoutHeight calldata timeoutHeight,
+        uint64 timeoutTimestamp,
+        string calldata memo
+    ) external returns (uint64 sequence);
+}

--- a/src/tests/IBCTest.sol
+++ b/src/tests/IBCTest.sol
@@ -7,11 +7,7 @@ import {IIBCModule} from "../IBC.sol";
 contract IBCTest {
     error ForcedRevert();
 
-    IIBCModule public immutable IBC;
-
-    constructor(address ibcAddress) {
-        IBC = IIBCModule(ibcAddress);
-    }
+    IIBCModule public constant IBC = IIBCModule(0x0000000000000000000000000000000000000069);
 
     function transfer(
         string calldata sourceChannel,

--- a/src/tests/IBCTest.sol
+++ b/src/tests/IBCTest.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IIBCModule} from "../IBC.sol";
+
+/// @notice Integration helper for exercising the IBC precompile from a contract.
+contract IBCTest {
+    error ForcedRevert();
+
+    IIBCModule public immutable IBC;
+
+    constructor(address ibcAddress) {
+        IBC = IIBCModule(ibcAddress);
+    }
+
+    function transfer(
+        string calldata sourceChannel,
+        string calldata receiver,
+        address token,
+        uint256 amount,
+        IIBCModule.TimeoutHeight calldata timeoutHeight,
+        uint64 timeoutTimestamp,
+        string calldata memo
+    ) external returns (uint64 sequence) {
+        return IBC.transfer(sourceChannel, receiver, token, amount, timeoutHeight, timeoutTimestamp, memo);
+    }
+
+    /// @notice Used to verify that an enclosing EVM revert rolls back the IBC send.
+    function transferThenRevert(
+        string calldata sourceChannel,
+        string calldata receiver,
+        address token,
+        uint256 amount,
+        IIBCModule.TimeoutHeight calldata timeoutHeight,
+        uint64 timeoutTimestamp,
+        string calldata memo
+    ) external {
+        IBC.transfer(sourceChannel, receiver, token, amount, timeoutHeight, timeoutTimestamp, memo);
+        revert ForcedRevert();
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for initiating synchronous ICS-20 token transfers through the IBC transfer precompile.
  - Transfers now support source channels, recipients, token amounts, timeout settings, and optional memos.
  - Successful transfers return the outbound packet sequence.
  - Documented rollback behavior, refunds for acknowledgements and timeouts, validation limits, and failure conditions.

- **Documentation**
  - Added the precompile address, interface details, usage behavior, and links to related IBC semantics documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->